### PR TITLE
Implement oral examination management tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,57 @@
-# examination-tool
-A tool to facilitate oral examinations at universities.
+# Examination Tool
+
+Ein leichtgewichtiges Web-Tool zur Unterstützung mündlicher Prüfungen. Es kombiniert die Verwaltung von Aufgaben, Studierenden und Kategorien mit einer automatischen Zuweisung zufälliger Aufgaben unter Berücksichtigung von Abhängigkeiten.
+
+## Funktionsumfang
+
+- **Studierendenverwaltung**: Import einer vorab bekannten Liste von Studierenden aus einer XLSX-Datei. Paarprüfungen werden automatisch über die Spalte `Partner` erkannt und als gemeinsame Gruppe abgelegt.
+- **Aufgabenbank**: Aufgaben lassen sich in Markdown (inkl. LaTeX via MathJax) verfassen. Jede Aufgabe besitzt eine Ober- und Unterkategorie sowie optionale Hinweise und Lösungen. Abhängigkeiten zwischen Aufgaben werden berücksichtigt.
+- **Kategorien**: Konfiguriere, wie viele Aufgaben pro Kategorie während einer Prüfung gezogen werden sollen.
+- **Prüfungssitzungen**: Starte mit einem Klick eine Prüfung für eine oder zwei Personen. Der Dozenten-Bildschirm zeigt Aufgaben inklusive Hinweise und Lösungen an; parallel steht eine Studierendenansicht ohne vertrauliche Informationen zur Verfügung. Die Studierendenansicht aktualisiert sich automatisch.
+
+## Installation
+
+1. Optional: Virtuelle Umgebung anlegen
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+   ```
+
+2. Abhängigkeiten installieren
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Datenbanktabellen werden beim ersten Start automatisch erstellt (SQLite `examination.db`).
+
+## Anwendung starten
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Anschließend steht die Anwendung unter <http://127.0.0.1:8000> zur Verfügung.
+
+## Datenimport
+
+- Erwartete XLSX-Spalten (Groß-/Kleinschreibung egal):
+  - `Name` (Pflicht)
+  - `Partner` (optional, Name der zweiten Person in einer Paarprüfung)
+  - `Group` (optional, individueller Anzeigename der Gruppe)
+- Jede Gruppe wird nur einmal angelegt, auch wenn mehrere Zeilen denselben Partner enthalten.
+
+## Tests ausführen
+
+```bash
+pytest
+```
+
+## Hinweis zu Markdown und Formeln
+
+Markdown-Inhalte werden serverseitig in HTML gerendert und via MathJax im Browser dargestellt. Verwende `\( ... \)` oder `$$ ... $$` für mathematische Formeln.
+
+## Lizenz
+
+Dieses Projekt dient als Referenzimplementierung und kann frei erweitert oder an eigene Anforderungen angepasst werden.

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+DATABASE_URL = "sqlite:///./examination.db"
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    future=True,
+)
+
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+class Base(DeclarativeBase):
+    """Base declarative class for the SQLAlchemy models."""
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def get_db() -> Iterator[Session]:
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def init_db() -> None:
+    from . import models  # noqa: F401
+
+    Base.metadata.create_all(bind=engine)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from io import BytesIO
+from typing import List, Optional
+
+from fastapi import (
+    Depends,
+    FastAPI,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    UploadFile,
+)
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, joinedload
+
+from .db import get_db, init_db
+from .models import (
+    CategoryRequirement,
+    ExamSession,
+    ExamTaskAssignment,
+    StudentGroup,
+    Task,
+)
+from .services.exam_service import (
+    ExamGenerationError,
+    build_exam_payload,
+    generate_exam_for_group,
+    regenerate_exam,
+)
+from .services.markdown_service import render_markdown
+from .services.student_import_service import import_students_from_excel
+
+app = FastAPI(title="Examination Tool", default_response_class=HTMLResponse)
+templates = Jinja2Templates(directory="app/templates")
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    init_db()
+
+
+@app.get("/", response_class=HTMLResponse)
+def index(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
+    groups = (
+        db.scalars(select(StudentGroup).order_by(StudentGroup.label)).unique().all()
+    )
+    category_requirements = db.scalars(select(CategoryRequirement).order_by(CategoryRequirement.category)).all()
+    tasks_count = db.scalar(select(func.count()).select_from(Task)) or 0
+    latest_exam = db.scalars(
+        select(ExamSession)
+        .options(joinedload(ExamSession.group).joinedload(StudentGroup.students))
+        .order_by(ExamSession.started_at.desc())
+        .limit(1)
+    ).unique().first()
+
+    return templates.TemplateResponse(
+        "index.html",
+        {
+            "request": request,
+            "groups": groups,
+            "category_requirements": category_requirements,
+            "tasks_count": tasks_count,
+            "latest_exam": latest_exam,
+        },
+    )
+
+
+@app.get("/students/import", response_class=HTMLResponse)
+def import_students_form(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse("students_import.html", {"request": request, "result": None})
+
+
+@app.post("/students/import", response_class=HTMLResponse)
+async def import_students(
+    request: Request,
+    upload: UploadFile = File(...),
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    if not upload.filename:
+        raise HTTPException(status_code=400, detail="Keine Datei hochgeladen.")
+
+    data = await upload.read()
+    buffer = BytesIO(data)
+    result = import_students_from_excel(db, buffer)
+    db.commit()
+
+    return templates.TemplateResponse(
+        "students_import.html",
+        {
+            "request": request,
+            "result": result,
+            "filename": upload.filename,
+        },
+    )
+
+
+@app.get("/tasks", response_class=HTMLResponse)
+def list_tasks(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
+    tasks = (
+        db.scalars(select(Task).order_by(Task.category, Task.subcategory, Task.title))
+        .unique()
+        .all()
+    )
+    rendered_tasks = [
+        {
+            "task": task,
+            "statement_html": render_markdown(task.statement_markdown),
+            "hints_html": render_markdown(task.hints_markdown),
+            "solution_html": render_markdown(task.solution_markdown),
+        }
+        for task in tasks
+    ]
+    return templates.TemplateResponse(
+        "tasks_list.html",
+        {"request": request, "tasks": rendered_tasks},
+    )
+
+
+@app.get("/tasks/new", response_class=HTMLResponse)
+def new_task_form(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
+    all_tasks = db.scalars(select(Task).order_by(Task.title)).unique().all()
+    return templates.TemplateResponse(
+        "tasks_form.html",
+        {
+            "request": request,
+            "task": None,
+            "all_tasks": all_tasks,
+        },
+    )
+
+
+@app.get("/tasks/{task_id}/edit", response_class=HTMLResponse)
+def edit_task_form(task_id: int, request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
+    task = db.get(Task, task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Aufgabe nicht gefunden")
+
+    all_tasks = db.scalars(select(Task).order_by(Task.title)).unique().all()
+    return templates.TemplateResponse(
+        "tasks_form.html",
+        {
+            "request": request,
+            "task": task,
+            "all_tasks": all_tasks,
+        },
+    )
+
+
+@app.post("/tasks", response_class=HTMLResponse)
+async def create_task(
+    request: Request,
+    title: str = Form(...),
+    category: str = Form(...),
+    subcategory: Optional[str] = Form(None),
+    statement_markdown: str = Form(...),
+    hints_markdown: Optional[str] = Form(None),
+    solution_markdown: Optional[str] = Form(None),
+    dependency_ids: Optional[str] = Form(None),
+    db: Session = Depends(get_db),
+) -> Response:
+    task = Task(
+        title=title.strip(),
+        category=category.strip(),
+        subcategory=subcategory.strip() if subcategory else None,
+        statement_markdown=statement_markdown,
+        hints_markdown=hints_markdown,
+        solution_markdown=solution_markdown,
+    )
+    db.add(task)
+    db.flush()
+
+    if dependency_ids:
+        dependencies = _parse_dependency_ids(dependency_ids, db, task.id)
+        task.dependencies = dependencies
+
+    db.commit()
+    return RedirectResponse(url="/tasks", status_code=303)
+
+
+@app.post("/tasks/{task_id}", response_class=HTMLResponse)
+async def update_task(
+    task_id: int,
+    request: Request,
+    title: str = Form(...),
+    category: str = Form(...),
+    subcategory: Optional[str] = Form(None),
+    statement_markdown: str = Form(...),
+    hints_markdown: Optional[str] = Form(None),
+    solution_markdown: Optional[str] = Form(None),
+    dependency_ids: Optional[str] = Form(None),
+    db: Session = Depends(get_db),
+) -> Response:
+    task = db.get(Task, task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Aufgabe nicht gefunden")
+
+    task.title = title.strip()
+    task.category = category.strip()
+    task.subcategory = subcategory.strip() if subcategory else None
+    task.statement_markdown = statement_markdown
+    task.hints_markdown = hints_markdown
+    task.solution_markdown = solution_markdown
+
+    if dependency_ids is not None:
+        task.dependencies = _parse_dependency_ids(dependency_ids, db, task.id)
+
+    db.commit()
+    return RedirectResponse(url="/tasks", status_code=303)
+
+
+@app.post("/tasks/{task_id}/delete")
+def delete_task(task_id: int, db: Session = Depends(get_db)) -> Response:
+    task = db.get(Task, task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Aufgabe nicht gefunden")
+    db.delete(task)
+    db.commit()
+    return RedirectResponse(url="/tasks", status_code=303)
+
+
+@app.get("/categories", response_class=HTMLResponse)
+def list_categories(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
+    categories = (
+        db.scalars(select(CategoryRequirement).order_by(CategoryRequirement.category)).all()
+    )
+    return templates.TemplateResponse(
+        "categories.html",
+        {"request": request, "categories": categories},
+    )
+
+
+@app.post("/categories")
+async def save_category(
+    category: str = Form(...),
+    required_count: int = Form(...),
+    category_id: Optional[int] = Form(None),
+    db: Session = Depends(get_db),
+) -> Response:
+    if category_id:
+        requirement = db.get(CategoryRequirement, category_id)
+        if not requirement:
+            raise HTTPException(status_code=404, detail="Kategorie nicht gefunden")
+        requirement.category = category.strip()
+        requirement.required_count = required_count
+    else:
+        requirement = CategoryRequirement(category=category.strip(), required_count=required_count)
+        db.add(requirement)
+
+    db.commit()
+    return RedirectResponse(url="/categories", status_code=303)
+
+
+@app.post("/categories/{category_id}/delete")
+def delete_category(category_id: int, db: Session = Depends(get_db)) -> Response:
+    requirement = db.get(CategoryRequirement, category_id)
+    if not requirement:
+        raise HTTPException(status_code=404, detail="Kategorie nicht gefunden")
+    db.delete(requirement)
+    db.commit()
+    return RedirectResponse(url="/categories", status_code=303)
+
+
+@app.post("/exams")
+def create_exam(group_id: int = Form(...), db: Session = Depends(get_db)) -> Response:
+    try:
+        exam = generate_exam_for_group(db, group_id)
+        db.commit()
+    except ExamGenerationError as exc:
+        db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ValueError as exc:
+        db.rollback()
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return RedirectResponse(url=f"/exams/{exam.id}/teacher", status_code=303)
+
+
+@app.post("/exams/{exam_id}/regenerate")
+def regenerate_exam_tasks(exam_id: int, db: Session = Depends(get_db)) -> Response:
+    try:
+        exam = regenerate_exam(db, exam_id)
+        db.commit()
+    except ExamGenerationError as exc:
+        db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ValueError as exc:
+        db.rollback()
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return RedirectResponse(url=f"/exams/{exam.id}/teacher", status_code=303)
+
+
+@app.get("/exams/{exam_id}/teacher", response_class=HTMLResponse)
+def show_exam_teacher(exam_id: int, request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
+    exam = db.scalars(
+        select(ExamSession)
+        .options(joinedload(ExamSession.group).joinedload(StudentGroup.students))
+        .options(joinedload(ExamSession.assignments).joinedload(ExamTaskAssignment.task))
+        .where(ExamSession.id == exam_id)
+    ).unique().first()
+    if not exam:
+        raise HTTPException(status_code=404, detail="Prüfungssitzung nicht gefunden")
+
+    payload = build_exam_payload(exam, include_solutions=True)
+    return templates.TemplateResponse(
+        "exam_teacher.html",
+        {"request": request, "exam": payload},
+    )
+
+
+@app.get("/exams/{exam_id}/student", response_class=HTMLResponse)
+def show_exam_student(exam_id: int, request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
+    exam = db.get(ExamSession, exam_id)
+    if not exam:
+        raise HTTPException(status_code=404, detail="Prüfungssitzung nicht gefunden")
+    return templates.TemplateResponse(
+        "exam_student.html",
+        {"request": request, "exam_id": exam_id},
+    )
+
+
+@app.get("/api/exams/{exam_id}", response_class=JSONResponse)
+def get_exam_data(
+    exam_id: int,
+    include_solutions: bool = Query(False),
+    db: Session = Depends(get_db),
+) -> JSONResponse:
+    exam = db.scalars(
+        select(ExamSession)
+        .options(joinedload(ExamSession.group).joinedload(StudentGroup.students))
+        .options(joinedload(ExamSession.assignments).joinedload(ExamTaskAssignment.task))
+        .where(ExamSession.id == exam_id)
+    ).unique().first()
+    if not exam:
+        raise HTTPException(status_code=404, detail="Prüfungssitzung nicht gefunden")
+    payload = build_exam_payload(exam, include_solutions=include_solutions)
+    return JSONResponse(payload)
+
+
+def _parse_dependency_ids(raw_value: str, db: Session, current_task_id: Optional[int]) -> List[Task]:
+    dependency_ids: List[int] = []
+    for item in raw_value.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            dependency_id = int(item)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=f"Ungültige Abhängigkeits-ID: {item}") from exc
+        if dependency_id == current_task_id:
+            raise HTTPException(status_code=400, detail="Eine Aufgabe kann nicht von sich selbst abhängen.")
+        dependency_ids.append(dependency_id)
+
+    dependencies = []
+    for dep_id in dependency_ids:
+        task = db.get(Task, dep_id)
+        if not task:
+            raise HTTPException(status_code=404, detail=f"Abhängige Aufgabe mit ID {dep_id} wurde nicht gefunden.")
+        dependencies.append(task)
+    return dependencies

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Sequence
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Table, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .db import Base
+
+
+task_dependencies = Table(
+    "task_dependencies",
+    Base.metadata,
+    Column("task_id", ForeignKey("tasks.id", ondelete="CASCADE"), primary_key=True),
+    Column(
+        "depends_on_task_id",
+        ForeignKey("tasks.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+)
+
+
+class StudentGroup(Base):
+    __tablename__ = "student_groups"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    label: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+
+    students: Mapped[List[Student]] = relationship(
+        "Student",
+        back_populates="group",
+        cascade="all, delete-orphan",
+        lazy="joined",
+    )
+    exams: Mapped[List[ExamSession]] = relationship(
+        "ExamSession", back_populates="group", cascade="all, delete-orphan"
+    )
+
+
+class Student(Base):
+    __tablename__ = "students"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    full_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    group_id: Mapped[int] = mapped_column(ForeignKey("student_groups.id", ondelete="CASCADE"))
+
+    group: Mapped[StudentGroup] = relationship("StudentGroup", back_populates="students")
+
+
+class Task(Base):
+    __tablename__ = "tasks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    category: Mapped[str] = mapped_column(String(255), nullable=False)
+    subcategory: Mapped[str | None] = mapped_column(String(255))
+    statement_markdown: Mapped[str] = mapped_column(Text, nullable=False)
+    hints_markdown: Mapped[str | None] = mapped_column(Text)
+    solution_markdown: Mapped[str | None] = mapped_column(Text)
+
+    dependencies: Mapped[List[Task]] = relationship(
+        "Task",
+        secondary=task_dependencies,
+        primaryjoin=id == task_dependencies.c.task_id,
+        secondaryjoin=id == task_dependencies.c.depends_on_task_id,
+        backref="dependents",
+        lazy="joined",
+    )
+
+
+class CategoryRequirement(Base):
+    __tablename__ = "category_requirements"
+    __table_args__ = (UniqueConstraint("category", name="uq_category"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    category: Mapped[str] = mapped_column(String(255), nullable=False)
+    required_count: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+
+class ExamSession(Base):
+    __tablename__ = "exam_sessions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    group_id: Mapped[int] = mapped_column(ForeignKey("student_groups.id", ondelete="CASCADE"))
+    started_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    group: Mapped[StudentGroup] = relationship("StudentGroup", back_populates="exams")
+    assignments: Mapped[List[ExamTaskAssignment]] = relationship(
+        "ExamTaskAssignment",
+        back_populates="exam",
+        order_by="ExamTaskAssignment.position",
+        cascade="all, delete-orphan",
+    )
+
+
+class ExamTaskAssignment(Base):
+    __tablename__ = "exam_task_assignments"
+    __table_args__ = (UniqueConstraint("exam_id", "task_id", name="uq_exam_task"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    exam_id: Mapped[int] = mapped_column(ForeignKey("exam_sessions.id", ondelete="CASCADE"))
+    task_id: Mapped[int] = mapped_column(ForeignKey("tasks.id", ondelete="CASCADE"))
+    position: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    category: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    exam: Mapped[ExamSession] = relationship("ExamSession", back_populates="assignments")
+    task: Mapped[Task] = relationship("Task")
+
+
+__all__: Sequence[str] = (
+    "Student",
+    "StudentGroup",
+    "Task",
+    "ExamSession",
+    "ExamTaskAssignment",
+    "CategoryRequirement",
+    "task_dependencies",
+)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class StudentBase(BaseModel):
+    full_name: str = Field(..., min_length=1, max_length=255)
+
+
+class StudentRead(StudentBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class StudentGroupRead(BaseModel):
+    id: int
+    label: str
+    students: List[StudentRead]
+
+    class Config:
+        orm_mode = True
+
+
+class TaskBase(BaseModel):
+    title: str
+    category: str
+    subcategory: Optional[str]
+    statement_markdown: str
+    hints_markdown: Optional[str]
+    solution_markdown: Optional[str]
+    dependency_ids: List[int] = []
+
+
+class TaskCreate(TaskBase):
+    pass
+
+
+class TaskUpdate(TaskBase):
+    pass
+
+
+class TaskRead(BaseModel):
+    id: int
+    title: str
+    category: str
+    subcategory: Optional[str]
+    statement_markdown: str
+    hints_markdown: Optional[str]
+    solution_markdown: Optional[str]
+    dependencies: List[int]
+
+    class Config:
+        orm_mode = True
+
+
+class CategoryRequirementBase(BaseModel):
+    category: str
+    required_count: int
+
+
+class CategoryRequirementCreate(CategoryRequirementBase):
+    pass
+
+
+class CategoryRequirementRead(CategoryRequirementBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class ExamTaskOut(BaseModel):
+    task_id: int
+    title: str
+    category: str
+    subcategory: Optional[str]
+    statement_html: str
+    hints_html: Optional[str]
+    solution_html: Optional[str]
+    position: int
+
+
+class ExamSessionOut(BaseModel):
+    exam_id: int
+    group: StudentGroupRead
+    tasks: List[ExamTaskOut]
+    started_at: datetime
+

--- a/app/services/exam_service.py
+++ b/app/services/exam_service.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import random
+from typing import List, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, joinedload
+
+from ..models import (
+    CategoryRequirement,
+    ExamSession,
+    ExamTaskAssignment,
+    StudentGroup,
+    Task,
+)
+from .markdown_service import render_markdown
+
+
+class ExamGenerationError(RuntimeError):
+    """Raised when an exam could not be generated."""
+
+
+def _dependencies_satisfied(task: Task, selected_ids: set[int]) -> bool:
+    return all(dependency.id in selected_ids for dependency in task.dependencies)
+
+
+def _collect_tasks_by_category(tasks: Sequence[Task]) -> dict[str, List[Task]]:
+    tasks_by_category: dict[str, List[Task]] = {}
+    for task in tasks:
+        tasks_by_category.setdefault(task.category, []).append(task)
+    return tasks_by_category
+
+
+def _choose_tasks_for_requirements(
+    requirements: Sequence[CategoryRequirement],
+    tasks_by_category: dict[str, List[Task]],
+    rng: random.Random,
+) -> List[Task]:
+    remaining = list(requirements)
+    rng.shuffle(remaining)
+    selected: List[Task] = []
+    selected_ids: set[int] = set()
+
+    progress = True
+    while remaining and progress:
+        progress = False
+        for requirement in list(remaining):
+            candidates = [
+                task
+                for task in tasks_by_category.get(requirement.category, [])
+                if task.id not in selected_ids and _dependencies_satisfied(task, selected_ids)
+            ]
+            if len(candidates) < requirement.required_count:
+                continue
+
+            chosen = rng.sample(candidates, requirement.required_count)
+            selected.extend(chosen)
+            selected_ids.update(task.id for task in chosen)
+            remaining.remove(requirement)
+            progress = True
+
+    if remaining:
+        missing = ", ".join(req.category for req in remaining)
+        raise ExamGenerationError(
+            "Nicht genügend Aufgaben verfügbar, um die Anforderungen zu erfüllen (fehlende Kategorien:"
+            f" {missing})."
+        )
+
+    return selected
+
+
+def _apply_tasks_to_exam(db: Session, exam: ExamSession, tasks: Sequence[Task]) -> None:
+    for assignment in list(exam.assignments):
+        db.delete(assignment)
+    db.flush()
+
+    for position, task in enumerate(tasks, start=1):
+        assignment = ExamTaskAssignment(
+            exam_id=exam.id,
+            task_id=task.id,
+            position=position,
+            category=task.category,
+        )
+        db.add(assignment)
+
+    db.flush()
+    db.refresh(exam)
+
+
+def generate_exam_for_group(db: Session, group_id: int, rng: random.Random | None = None) -> ExamSession:
+    rng = rng or random.Random()
+
+    group = db.get(StudentGroup, group_id)
+    if not group:
+        raise ValueError("Die ausgewählte Gruppe existiert nicht.")
+
+    requirements = db.scalars(select(CategoryRequirement)).all()
+    if not requirements:
+        raise ExamGenerationError("Es wurden noch keine Kategorienanforderungen definiert.")
+
+    tasks = (
+        db.scalars(select(Task).options(joinedload(Task.dependencies))).unique().all()
+    )
+    tasks_by_category = _collect_tasks_by_category(tasks)
+
+    selected_tasks = _choose_tasks_for_requirements(requirements, tasks_by_category, rng)
+
+    exam = ExamSession(group_id=group_id)
+    db.add(exam)
+    db.flush()
+
+    _apply_tasks_to_exam(db, exam, selected_tasks)
+    return exam
+
+
+def regenerate_exam(db: Session, exam_id: int, rng: random.Random | None = None) -> ExamSession:
+    rng = rng or random.Random()
+    exam = db.get(ExamSession, exam_id)
+    if not exam:
+        raise ValueError("Die Prüfungssitzung wurde nicht gefunden.")
+
+    requirements = db.scalars(select(CategoryRequirement)).all()
+    tasks = (
+        db.scalars(select(Task).options(joinedload(Task.dependencies))).unique().all()
+    )
+    tasks_by_category = _collect_tasks_by_category(tasks)
+    selected_tasks = _choose_tasks_for_requirements(requirements, tasks_by_category, rng)
+    _apply_tasks_to_exam(db, exam, selected_tasks)
+    return exam
+
+
+def build_exam_payload(exam: ExamSession, include_solutions: bool) -> dict:
+    tasks_payload = []
+    sorted_assignments = sorted(exam.assignments, key=lambda a: a.position)
+    for assignment in sorted_assignments:
+        task = assignment.task
+        tasks_payload.append(
+            {
+                "task_id": task.id,
+                "title": task.title,
+                "category": task.category,
+                "subcategory": task.subcategory,
+                "statement_html": render_markdown(task.statement_markdown) or "",
+                "hints_html": render_markdown(task.hints_markdown) if include_solutions else None,
+                "solution_html": render_markdown(task.solution_markdown)
+                if include_solutions
+                else None,
+                "position": assignment.position,
+            }
+        )
+
+    group_payload = {
+        "id": exam.group.id,
+        "label": exam.group.label,
+        "students": [
+            {"id": student.id, "full_name": student.full_name} for student in exam.group.students
+        ],
+    }
+
+    return {
+        "exam_id": exam.id,
+        "group": group_payload,
+        "tasks": tasks_payload,
+        "started_at": exam.started_at,
+    }

--- a/app/services/markdown_service.py
+++ b/app/services/markdown_service.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+import bleach
+import markdown
+
+
+ALLOWED_TAGS: Iterable[str] = bleach.sanitizer.ALLOWED_TAGS.union(
+    {
+        "p",
+        "pre",
+        "code",
+        "span",
+        "div",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "table",
+        "thead",
+        "tbody",
+        "tr",
+        "th",
+        "td",
+        "ul",
+        "ol",
+        "li",
+        "strong",
+        "em",
+    }
+)
+
+ALLOWED_ATTRIBUTES: Dict[str, Iterable[str]] = {
+    **bleach.sanitizer.ALLOWED_ATTRIBUTES,
+    "span": ["class"],
+    "div": ["class"],
+    "code": ["class"],
+    "th": ["align"],
+    "td": ["align"],
+}
+
+
+def render_markdown(content: str | None) -> str | None:
+    if not content:
+        return None
+
+    html = markdown.markdown(
+        content,
+        extensions=[
+            "fenced_code",
+            "tables",
+            "codehilite",
+            "md_in_html",
+        ],
+        output_format="html5",
+    )
+    cleaned = bleach.clean(html, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES)
+    return cleaned

--- a/app/services/student_import_service.py
+++ b/app/services/student_import_service.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import IO, Dict, List, Tuple
+
+import pandas as pd
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..models import Student, StudentGroup
+
+
+@dataclass
+class ImportResult:
+    created_groups: int
+    created_students: int
+    skipped_rows: int
+    errors: List[str]
+
+
+REQUIRED_COLUMNS = {"name"}
+OPTIONAL_COLUMNS = {"partner", "group"}
+
+
+def _normalise_columns(columns: List[str]) -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    for column in columns:
+        normalised = column.strip().lower()
+        mapping[normalised] = column
+    return mapping
+
+
+def _extract_value(row: pd.Series, mapping: Dict[str, str], key: str) -> str | None:
+    column = mapping.get(key)
+    if column is None:
+        return None
+    value = row.get(column)
+    if isinstance(value, float) and pd.isna(value):
+        return None
+    if pd.isna(value):
+        return None
+    if value is None:
+        return None
+    return str(value).strip()
+
+
+def import_students_from_excel(db: Session, file: IO[bytes]) -> ImportResult:
+    frame = pd.read_excel(file)
+    if frame.empty:
+        return ImportResult(created_groups=0, created_students=0, skipped_rows=0, errors=["Die Datei ist leer."])
+
+    column_map = _normalise_columns(list(frame.columns))
+    missing_columns = REQUIRED_COLUMNS - set(column_map)
+    if missing_columns:
+        return ImportResult(
+            created_groups=0,
+            created_students=0,
+            skipped_rows=len(frame),
+            errors=[
+                "Die Datei muss mindestens eine Spalte 'Name' enthalten."
+            ],
+        )
+
+    existing_groups = {group.label: group for group in db.scalars(select(StudentGroup)).all()}
+    created_groups = 0
+    created_students = 0
+    skipped_rows = 0
+    errors: List[str] = []
+
+    processed_group_keys: Dict[Tuple[str, ...], StudentGroup] = {}
+
+    for index, row in frame.iterrows():
+        primary_name = _extract_value(row, column_map, "name")
+        if not primary_name:
+            skipped_rows += 1
+            errors.append(f"Zeile {index + 2}: Kein Name angegeben.")
+            continue
+
+        partner_name = _extract_value(row, column_map, "partner")
+        explicit_group_label = _extract_value(row, column_map, "group")
+
+        participants = [primary_name]
+        if partner_name and partner_name != primary_name:
+            participants.append(partner_name)
+
+        group_key = tuple(sorted(participants))
+        label = explicit_group_label or " & ".join(group_key)
+
+        group = existing_groups.get(label) or processed_group_keys.get(group_key)
+        if not group:
+            group = StudentGroup(label=label)
+            db.add(group)
+            db.flush()
+            existing_groups[label] = group
+            processed_group_keys[group_key] = group
+            created_groups += 1
+
+        # ensure each participant is present
+        for participant in group_key:
+            existing_student = next((s for s in group.students if s.full_name == participant), None)
+            if existing_student:
+                continue
+            group.students.append(Student(full_name=participant))
+            created_students += 1
+
+    db.flush()
+    return ImportResult(
+        created_groups=created_groups,
+        created_students=created_students,
+        skipped_rows=skipped_rows,
+        errors=errors,
+    )

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,214 @@
+:root {
+  color-scheme: light;
+  font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  --primary: #2d5be3;
+  --background: #f7f8fb;
+  --text: #222;
+  --muted: #6b7280;
+  --border: #e5e7eb;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--text);
+}
+
+.container {
+  margin: 0 auto;
+  padding: 1.5rem;
+  max-width: 1100px;
+}
+
+.topbar {
+  background: white;
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 1px 4px rgba(15, 23, 42, 0.08);
+}
+
+.brand a {
+  text-decoration: none;
+  color: var(--primary);
+}
+
+.topbar nav {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.topbar nav a {
+  color: var(--muted);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.topbar nav a:hover {
+  color: var(--primary);
+}
+
+main.container {
+  padding-top: 2rem;
+}
+
+.card {
+  background: white;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.stats-grid strong {
+  display: block;
+  font-size: 2rem;
+  color: var(--primary);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table thead {
+  background: #eef2ff;
+}
+
+.table th,
+.table td {
+  border: 1px solid var(--border);
+  padding: 0.75rem;
+  text-align: left;
+}
+
+.table tbody tr:nth-child(odd) {
+  background: #fafbff;
+}
+
+button,
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  background: var(--primary);
+  color: white;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 1rem;
+  text-decoration: none;
+}
+
+button.secondary,
+.button.secondary {
+  background: #64748b;
+}
+
+button.danger,
+.button.danger {
+  background: #dc2626;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+form .form-row {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+form label {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+form input,
+form textarea,
+form select {
+  padding: 0.6rem 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+textarea {
+  min-height: 160px;
+}
+
+.task-card {
+  border-left: 4px solid var(--primary);
+  margin-bottom: 1rem;
+  padding-left: 1rem;
+}
+
+.task-metadata {
+  color: var(--muted);
+  font-size: 0.95rem;
+  margin-bottom: 0.5rem;
+}
+
+.alert {
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.alert.success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.alert.error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.exam-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.exam-task {
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  background: white;
+}
+
+.exam-task h2 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.exam-task .section-title {
+  color: var(--muted);
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  margin-top: 1rem;
+}
+
+@media (max-width: 640px) {
+  .container {
+    padding: 1rem;
+  }
+
+  .topbar nav {
+    gap: 0.5rem;
+  }
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}Examination Tool{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', path='styles.css') }}" />
+    <script>
+      window.MathJax = {
+        tex: {
+          inlineMath: [['$', '$'], ['\\(', '\\)']],
+          displayMath: [['$$', '$$'], ['\\[', '\\]']]
+        },
+        options: {
+          skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
+        }
+      };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" async></script>
+    {% block head_extra %}{% endblock %}
+  </head>
+  <body>
+    <header class="topbar">
+      <div class="container">
+        <h1 class="brand"><a href="/">Examination Tool</a></h1>
+        <nav>
+          <a href="/">Übersicht</a>
+          <a href="/students/import">Studierende importieren</a>
+          <a href="/tasks">Aufgaben</a>
+          <a href="/categories">Kategorien</a>
+        </nav>
+      </div>
+    </header>
+    <main class="container">
+      {% block content %}{% endblock %}
+    </main>
+    {% block scripts %}{% endblock %}
+  </body>
+</html>

--- a/app/templates/categories.html
+++ b/app/templates/categories.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+
+{% block title %}Kategorien · Examination Tool{% endblock %}
+
+{% block content %}
+  <section class="card">
+    <h2>Kategorien verwalten</h2>
+    <p>Lege fest, wie viele Aufgaben pro Kategorie zufällig ausgewählt werden. Jede Kategorie kann beliebig viele Aufgaben umfassen.</p>
+    <form method="post" action="/categories" style="margin-bottom:1.5rem;">
+      <h3>Neue Kategorie hinzufügen</h3>
+      <div class="form-row">
+        <label for="category">Kategorie</label>
+        <input id="category" type="text" name="category" required />
+      </div>
+      <div class="form-row">
+        <label for="required_count">Anzahl Aufgaben pro Prüfung</label>
+        <input id="required_count" type="number" min="1" name="required_count" value="1" required />
+      </div>
+      <button type="submit">Kategorie anlegen</button>
+    </form>
+
+    {% if not categories %}
+      <p>Noch keine Kategorien angelegt.</p>
+    {% else %}
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Kategorie</th>
+            <th>Aufgabenanzahl</th>
+            <th>Aktionen</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for category in categories %}
+            <tr>
+              <td>{{ category.category }}</td>
+              <td>
+                <form method="post" action="/categories">
+                  <input type="hidden" name="category_id" value="{{ category.id }}" />
+                  <input type="hidden" name="category" value="{{ category.category }}" />
+                  <input type="number" name="required_count" value="{{ category.required_count }}" min="1" required />
+                  <button type="submit" class="secondary">Speichern</button>
+                </form>
+              </td>
+              <td>
+                <form method="post" action="/categories/{{ category.id }}/delete" onsubmit="return confirm('Kategorie wirklich löschen?');">
+                  <button type="submit" class="danger">Löschen</button>
+                </form>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% endif %}
+  </section>
+{% endblock %}

--- a/app/templates/exam_student.html
+++ b/app/templates/exam_student.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+
+{% block title %}Prüfung · Studierendenansicht{% endblock %}
+
+{% block head_extra %}
+  <style>
+    header.topbar nav,
+    header.topbar .brand { display: none; }
+    body { background: #fff; }
+    main.container { max-width: 900px; }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <section class="card" id="student-app" data-exam-id="{{ exam_id }}">
+    <h2 id="group-label">Prüfung</h2>
+    <div class="task-metadata">Diese Ansicht blendet Hinweise und Lösungen automatisch aus.</div>
+    <div id="tasks" class="exam-layout" style="margin-top:1.5rem;">
+      <p>Lade Aufgaben...</p>
+    </div>
+  </section>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    const appElement = document.getElementById('student-app');
+    const tasksContainer = document.getElementById('tasks');
+    const groupLabel = document.getElementById('group-label');
+    const examId = appElement.dataset.examId;
+
+    async function fetchExam() {
+      try {
+        const response = await fetch(`/api/exams/${examId}`);
+        if (!response.ok) {
+          throw new Error('Fehler beim Laden der Aufgaben');
+        }
+        const payload = await response.json();
+        renderExam(payload);
+      } catch (error) {
+        tasksContainer.innerHTML = `<p class="alert error">${error.message}</p>`;
+      }
+    }
+
+    function renderExam(exam) {
+      groupLabel.textContent = `Prüfung für ${exam.group.label}`;
+      if (!exam.tasks.length) {
+        tasksContainer.innerHTML = '<p>Keine Aufgaben verfügbar.</p>';
+        return;
+      }
+      tasksContainer.innerHTML = exam.tasks
+        .map((task, index) => `
+          <article class="exam-task">
+            <h2>${index + 1}. ${task.title}</h2>
+            <div class="task-metadata">${task.category}${task.subcategory ? ' · ' + task.subcategory : ''}</div>
+            <div class="markdown">${task.statement_html}</div>
+          </article>
+        `)
+        .join('');
+      if (window.MathJax && window.MathJax.typesetPromise) {
+        window.MathJax.typesetPromise();
+      }
+    }
+
+    fetchExam();
+    setInterval(fetchExam, 7000);
+  </script>
+{% endblock %}

--- a/app/templates/exam_teacher.html
+++ b/app/templates/exam_teacher.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+
+{% block title %}Prüfung #{{ exam.exam_id }} · Examination Tool{% endblock %}
+
+{% block content %}
+  <section class="card">
+    <header style="display:flex; justify-content:space-between; align-items:center; gap:1rem; flex-wrap:wrap;">
+      <div>
+        <h2>Prüfung für {{ exam.group.label }}</h2>
+        <div class="task-metadata">
+          Studierende:
+          {% for student in exam.group.students %}
+            {{ student.full_name }}{% if not loop.last %}, {% endif %}
+          {% endfor %}
+        </div>
+        <div class="task-metadata">Gestartet am {{ exam.started_at.strftime('%d.%m.%Y %H:%M') }} Uhr</div>
+      </div>
+      <div style="display:flex; gap:0.5rem;">
+        <a class="button secondary" target="_blank" href="/exams/{{ exam.exam_id }}/student">Studierendenansicht öffnen</a>
+        <form method="post" action="/exams/{{ exam.exam_id }}/regenerate" onsubmit="return confirm('Aufgaben neu auslosen?');">
+          <button type="submit">Neue Aufgaben auslosen</button>
+        </form>
+      </div>
+    </header>
+    <div class="exam-layout" style="margin-top:1.5rem;">
+      {% for task in exam.tasks %}
+        <article class="exam-task">
+          <h2>{{ loop.index }}. {{ task.title }}</h2>
+          <div class="task-metadata">{{ task.category }}{% if task.subcategory %} · {{ task.subcategory }}{% endif %}</div>
+          <div class="markdown">{{ task.statement_html | safe }}</div>
+          {% if task.hints_html %}
+            <div class="section-title">Hinweise</div>
+            <div class="markdown">{{ task.hints_html | safe }}</div>
+          {% endif %}
+          {% if task.solution_html %}
+            <div class="section-title">Lösung</div>
+            <div class="markdown">{{ task.solution_html | safe }}</div>
+          {% endif %}
+        </article>
+      {% endfor %}
+    </div>
+  </section>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %}
+
+{% block title %}Übersicht · Examination Tool{% endblock %}
+
+{% block content %}
+  <section class="card">
+    <h2>Überblick</h2>
+    <p>Verwalte Studierende, Aufgaben und starte neue Prüfungssitzungen.</p>
+    <div class="stats-grid">
+      <div>
+        <strong>{{ tasks_count }}</strong>
+        <div>Aufgaben vorhanden</div>
+      </div>
+      <div>
+        <strong>{{ category_requirements|length }}</strong>
+        <div>Kategorien definiert</div>
+      </div>
+      <div>
+        <strong>{{ groups|length }}</strong>
+        <div>Gruppen verfügbar</div>
+      </div>
+    </div>
+  </section>
+
+  <section class="card">
+    <h2>Prüfung starten</h2>
+    {% if not groups %}
+      <p>Es wurden noch keine Studierenden importiert. Lade zuerst eine XLSX-Datei hoch.</p>
+    {% else %}
+      <p>Wähle eine Gruppe aus, um eine neue Prüfungssitzung zu erstellen. Es wird automatisch pro Kategorie eine zufällige Aufgabe ausgewählt.</p>
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Gruppe</th>
+            <th>Studierende</th>
+            <th>Aktion</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for group in groups %}
+            <tr>
+              <td>{{ group.label }}</td>
+              <td>
+                {% for student in group.students %}
+                  {{ student.full_name }}{% if not loop.last %}, {% endif %}
+                {% endfor %}
+              </td>
+              <td>
+                <form method="post" action="/exams">
+                  <input type="hidden" name="group_id" value="{{ group.id }}" />
+                  <button type="submit">Prüfung starten</button>
+                </form>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% endif %}
+  </section>
+
+  <section class="card">
+    <h2>Kategorien</h2>
+    {% if not category_requirements %}
+      <p>Definiere Kategorien, um die Auswahl der Aufgaben zu steuern.</p>
+    {% else %}
+      <ul>
+        {% for category in category_requirements %}
+          <li><strong>{{ category.category }}</strong>: {{ category.required_count }} Aufgabe(n)</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </section>
+
+  {% if latest_exam %}
+    <section class="card">
+      <h2>Letzte Prüfung</h2>
+      <p>
+        Gruppe <strong>{{ latest_exam.group.label }}</strong> &middot;
+        gestartet am {{ latest_exam.started_at.strftime('%d.%m.%Y %H:%M') }} Uhr
+      </p>
+      <a class="button secondary" href="/exams/{{ latest_exam.id }}/teacher">Prüfung ansehen</a>
+    </section>
+  {% endif %}
+{% endblock %}

--- a/app/templates/students_import.html
+++ b/app/templates/students_import.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+
+{% block title %}Studierende importieren · Examination Tool{% endblock %}
+
+{% block content %}
+  <section class="card">
+    <h2>Studierende importieren</h2>
+    <p>Lade eine XLSX-Datei mit den Studierendennamen hoch. Spaltenüberschriften werden in Groß-/Kleinschreibung ignoriert.</p>
+    <ul>
+      <li><strong>Name</strong> (Pflichtfeld)</li>
+      <li><strong>Partner</strong> (optional, Partnerin/Partner für Paarprüfungen)</li>
+      <li><strong>Group</strong> (optional, eigener Anzeigename für die Gruppe)</li>
+    </ul>
+    <form method="post" enctype="multipart/form-data">
+      <div class="form-row">
+        <label for="upload">XLSX-Datei</label>
+        <input id="upload" type="file" name="upload" accept=".xlsx" required />
+      </div>
+      <button type="submit">Import starten</button>
+    </form>
+  </section>
+
+  {% if result %}
+    <section class="card">
+      <h2>Import-Ergebnis</h2>
+      <p>Datei: <strong>{{ filename }}</strong></p>
+      <ul>
+        <li>{{ result.created_groups }} neue Gruppe(n)</li>
+        <li>{{ result.created_students }} neue Studierende</li>
+        <li>{{ result.skipped_rows }} übersprungene Zeilen</li>
+      </ul>
+      {% if result.errors %}
+        <div class="alert error">
+          <strong>Hinweise:</strong>
+          <ul>
+            {% for error in result.errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% else %}
+        <div class="alert success">Import erfolgreich abgeschlossen.</div>
+      {% endif %}
+      <a class="button secondary" href="/">Zurück zur Übersicht</a>
+    </section>
+  {% endif %}
+{% endblock %}

--- a/app/templates/tasks_form.html
+++ b/app/templates/tasks_form.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+
+{% if task %}
+  {% set page_title = 'Aufgabe bearbeiten' %}
+{% else %}
+  {% set page_title = 'Neue Aufgabe anlegen' %}
+{% endif %}
+
+{% block title %}{{ page_title }} · Examination Tool{% endblock %}
+
+{% block content %}
+  <section class="card">
+    <h2>{{ page_title }}</h2>
+    <form method="post" action="{% if task %}/tasks/{{ task.id }}{% else %}/tasks{% endif %}">
+      <div class="form-row">
+        <label for="title">Titel</label>
+        <input id="title" type="text" name="title" value="{{ task.title if task else '' }}" required />
+      </div>
+      <div class="form-row">
+        <label for="category">Kategorie</label>
+        <input id="category" type="text" name="category" value="{{ task.category if task else '' }}" required />
+      </div>
+      <div class="form-row">
+        <label for="subcategory">Unterkategorie</label>
+        <input id="subcategory" type="text" name="subcategory" value="{{ task.subcategory if task and task.subcategory else '' }}" />
+      </div>
+      <div class="form-row">
+        <label for="statement_markdown">Aufgabe (Markdown)</label>
+        <textarea id="statement_markdown" name="statement_markdown" required>{{ task.statement_markdown if task else '' }}</textarea>
+      </div>
+      <div class="form-row">
+        <label for="hints_markdown">Hinweise (Markdown, optional)</label>
+        <textarea id="hints_markdown" name="hints_markdown">{{ task.hints_markdown if task and task.hints_markdown else '' }}</textarea>
+      </div>
+      <div class="form-row">
+        <label for="solution_markdown">Lösung (Markdown, optional)</label>
+        <textarea id="solution_markdown" name="solution_markdown">{{ task.solution_markdown if task and task.solution_markdown else '' }}</textarea>
+      </div>
+      <div class="form-row">
+        <label for="dependency_ids">Abhängigkeiten (IDs, durch Komma getrennt)</label>
+        <input id="dependency_ids" type="text" name="dependency_ids" value="{% if task and task.dependencies %}{% for dep in task.dependencies %}{{ dep.id }}{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}" />
+        <small class="task-metadata">Wähle IDs aus der folgenden Liste, falls die Aufgabe von anderen Aufgaben abhängig ist.</small>
+      </div>
+      {% if all_tasks %}
+        <div class="form-row">
+          <label>Verfügbare Aufgaben</label>
+          <div class="task-metadata">
+            {% for other in all_tasks %}
+              #{{ other.id }} · {{ other.title }} ({{ other.category }})<br />
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+      <button type="submit">Speichern</button>
+      <a class="button secondary" href="/tasks">Abbrechen</a>
+    </form>
+  </section>
+{% endblock %}

--- a/app/templates/tasks_list.html
+++ b/app/templates/tasks_list.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+
+{% block title %}Aufgaben · Examination Tool{% endblock %}
+
+{% block content %}
+  <section class="card">
+    <div style="display:flex; justify-content:space-between; align-items:center;">
+      <h2>Aufgaben</h2>
+      <a class="button" href="/tasks/new">Neue Aufgabe</a>
+    </div>
+    {% if not tasks %}
+      <p>Noch keine Aufgaben vorhanden. Lege die erste Aufgabe an, um Prüfungen erstellen zu können.</p>
+    {% else %}
+      {% for item in tasks %}
+        {% set task = item.task %}
+        <article class="task-card">
+          <header>
+            <h3>#{{ task.id }} · {{ task.title }}</h3>
+            <div class="task-metadata">Kategorie: {{ task.category }}{% if task.subcategory %} &middot; Unterkategorie: {{ task.subcategory }}{% endif %}</div>
+          </header>
+          <div class="task-body">
+            <h4 class="section-title">Aufgabe</h4>
+            <div class="markdown">{{ item.statement_html | safe }}</div>
+            {% if item.hints_html %}
+              <h4 class="section-title">Hinweise</h4>
+              <div class="markdown">{{ item.hints_html | safe }}</div>
+            {% endif %}
+            {% if item.solution_html %}
+              <h4 class="section-title">Lösung</h4>
+              <div class="markdown">{{ item.solution_html | safe }}</div>
+            {% endif %}
+          </div>
+          <footer style="margin-top:1rem; display:flex; gap:0.5rem;">
+            <a class="button secondary" href="/tasks/{{ task.id }}/edit">Bearbeiten</a>
+            <form method="post" action="/tasks/{{ task.id }}/delete" onsubmit="return confirm('Aufgabe wirklich löschen?');">
+              <button type="submit" class="danger">Löschen</button>
+            </form>
+            {% if task.dependencies %}
+              <span class="task-metadata">Abhängigkeiten: {% for dep in task.dependencies %}#{{ dep.id }}{% if not loop.last %}, {% endif %}{% endfor %}</span>
+            {% endif %}
+          </footer>
+        </article>
+      {% endfor %}
+    {% endif %}
+  </section>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+fastapi==0.110.1
+uvicorn[standard]==0.29.0
+SQLAlchemy==2.0.30
+alembic==1.13.1
+Jinja2==3.1.3
+pydantic==1.10.15
+python-multipart==0.0.9
+pandas==2.2.2
+openpyxl==3.1.2
+markdown==3.6
+bleach==6.1.0
+pytest==8.1.1
+httpx==0.27.0

--- a/tests/test_exam_generation.py
+++ b/tests/test_exam_generation.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import random
+import sys
+from io import BytesIO
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from app.db import Base
+from app.models import CategoryRequirement, Student, StudentGroup, Task
+from app.services.exam_service import ExamGenerationError, generate_exam_for_group
+from app.services.student_import_service import import_students_from_excel
+
+
+@pytest.fixture()
+def session() -> Session:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(bind=engine)
+    TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _seed_group(session: Session) -> StudentGroup:
+    group = StudentGroup(label="Team Alpha")
+    student = Student(full_name="Max Mustermann", group=group)
+    session.add_all([group, student])
+    session.commit()
+    return group
+
+
+def test_generate_exam_respects_dependencies(session: Session) -> None:
+    group = _seed_group(session)
+    session.add_all(
+        [
+            CategoryRequirement(category="Analysis", required_count=1),
+            CategoryRequirement(category="Algebra", required_count=1),
+        ]
+    )
+
+    analysis_task = Task(
+        title="Analysis 1",
+        category="Analysis",
+        subcategory="Differential",
+        statement_markdown="**Aufgabe**",
+    )
+    algebra_task = Task(
+        title="Algebra 1",
+        category="Algebra",
+        subcategory="Gruppen",
+        statement_markdown="Beweise XYZ",
+    )
+    algebra_task.dependencies.append(analysis_task)
+
+    session.add_all([analysis_task, algebra_task])
+    session.commit()
+
+    exam = generate_exam_for_group(session, group.id, rng=random.Random(42))
+    session.commit()
+
+    assert len(exam.assignments) == 2
+    categories = {assignment.category for assignment in exam.assignments}
+    assert categories == {"Analysis", "Algebra"}
+
+    algebra_assignment = next(assignment for assignment in exam.assignments if assignment.category == "Algebra")
+    assert algebra_assignment.task.dependencies[0].id == analysis_task.id
+
+
+def test_generate_exam_fails_when_insufficient_tasks(session: Session) -> None:
+    group = _seed_group(session)
+    session.add(CategoryRequirement(category="Analysis", required_count=1))
+    session.commit()
+
+    with pytest.raises(ExamGenerationError):
+        generate_exam_for_group(session, group.id, rng=random.Random(1))
+
+
+def test_import_students_from_excel(session: Session) -> None:
+    data = pd.DataFrame(
+        {
+            "Name": ["Anna", "Bernd"],
+            "Partner": ["Bernd", "Anna"],
+        }
+    )
+    buffer = BytesIO()
+    data.to_excel(buffer, index=False)
+    buffer.seek(0)
+
+    result = import_students_from_excel(session, buffer)
+    session.commit()
+
+    assert result.created_groups == 1
+    assert result.created_students == 2
+    groups = session.scalars(select(StudentGroup)).unique().all()
+    assert len(groups) == 1
+    assert sorted(student.full_name for student in groups[0].students) == ["Anna", "Bernd"]


### PR DESCRIPTION
## Summary
- scaffold a FastAPI-based application for managing oral examinations, including student import, task authoring with Markdown, and configurable category requirements
- implement exam generation that respects task dependencies and provides dedicated lecturer and student views with MathJax-enabled rendering
- add Jinja templates, styling, and documentation plus pytest coverage for selection logic and Excel import

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3ec24d380832c9917e9e2bc240d9f