### PR TITLE
Add task images, category hierarchy, and live student view

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from io import BytesIO
+import base64
+import json
+import mimetypes
+from pathlib import Path
 from typing import List, Optional
+from uuid import uuid4
 
 from fastapi import (
     Depends,
@@ -17,16 +22,18 @@ from fastapi import (
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from sqlalchemy import func, select
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy import func, select, update
+from sqlalchemy.orm import Session, joinedload, selectinload
 
-from .db import get_db, init_db
+from .db import get_db, init_db, session_scope
 from .models import (
+    Category,
     CategoryRequirement,
     ExamSession,
     ExamTaskAssignment,
     StudentGroup,
     Task,
+    TaskImage,
 )
 from .services.exam_service import (
     ExamGenerationError,
@@ -36,15 +43,198 @@ from .services.exam_service import (
 )
 from .services.markdown_service import render_markdown
 from .services.student_import_service import import_students_from_excel
+from .schemas import MarkdownPreviewRequest
+
+STATIC_DIR = Path("app/static")
+UPLOAD_DIR = STATIC_DIR / "uploads"
 
 app = FastAPI(title="Examination Tool", default_response_class=HTMLResponse)
 templates = Jinja2Templates(directory="app/templates")
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 
+def _sync_category_nodes(db: Session) -> None:
+    existing = {
+        category.name: category
+        for category in db.scalars(
+            select(Category).where(Category.parent_id.is_(None))
+        )
+    }
+    requirements = db.scalars(select(CategoryRequirement)).all()
+    for requirement in requirements:
+        if requirement.category not in existing:
+            node = Category(name=requirement.category)
+            db.add(node)
+            existing[requirement.category] = node
+    db.flush()
+
+
+def _get_category_tree(db: Session) -> List[Category]:
+    return (
+        db.scalars(
+            select(Category)
+            .where(Category.parent_id.is_(None))
+            .options(selectinload(Category.children))
+            .order_by(Category.name)
+        )
+        .all()
+    )
+
+
+def _serialize_category_options(categories: List[Category]) -> List[dict]:
+    return [
+        {
+            "id": category.id,
+            "name": category.name,
+            "subcategories": [
+                {"id": sub.id, "name": sub.name} for sub in category.children
+            ],
+        }
+        for category in categories
+    ]
+
+
+def _get_category_selection_for_task(
+    db: Session, task: Task
+) -> tuple[Optional[int], Optional[int]]:
+    if not task:
+        return None, None
+
+    category_id: Optional[int] = None
+    subcategory_id: Optional[int] = None
+    if task.category:
+        category = db.scalars(
+            select(Category)
+            .where(Category.name == task.category)
+            .where(Category.parent_id.is_(None))
+        ).first()
+        if category:
+            category_id = category.id
+            if task.subcategory:
+                subcategory = db.scalars(
+                    select(Category)
+                    .where(Category.name == task.subcategory)
+                    .where(Category.parent_id == category.id)
+                ).first()
+                if subcategory:
+                    subcategory_id = subcategory.id
+    return category_id, subcategory_id
+
+
+def _resolve_category_selection(
+    db: Session, category_id: int, subcategory_id: Optional[int]
+) -> tuple[Category, Optional[Category]]:
+    category = db.get(Category, category_id)
+    if not category or category.parent_id is not None:
+        raise HTTPException(status_code=400, detail="Ungültige Kategorie ausgewählt.")
+
+    subcategory: Category | None = None
+    if subcategory_id:
+        subcategory = db.get(Category, subcategory_id)
+        if not subcategory or subcategory.parent_id != category.id:
+            raise HTTPException(
+                status_code=400, detail="Ungültige Unterkategorie ausgewählt."
+            )
+
+    return category, subcategory
+
+
+def _delete_image_file(image: TaskImage) -> None:
+    file_path = STATIC_DIR / image.file_path
+    try:
+        file_path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _guess_file_suffix(original_filename: str, mime_type: str | None) -> str:
+    suffix = Path(original_filename).suffix
+    if suffix:
+        return suffix
+    if mime_type:
+        guessed = mimetypes.guess_extension(mime_type)
+        if guessed:
+            return guessed
+    return ""
+
+
+async def _save_uploaded_images(task: Task, images: List[UploadFile]) -> None:
+    if not images:
+        return
+
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    existing_count = len(task.images)
+    for index, upload in enumerate(images):
+        if not upload.filename:
+            continue
+        if not upload.content_type or not upload.content_type.startswith("image/"):
+            raise HTTPException(status_code=400, detail="Nur Bilddateien sind erlaubt.")
+
+        suffix = _guess_file_suffix(upload.filename, upload.content_type)
+        unique_name = f"{uuid4().hex}{suffix}"
+        destination = UPLOAD_DIR / unique_name
+        content = await upload.read()
+        destination.write_bytes(content)
+
+        image = TaskImage(
+            task=task,
+            file_path=f"uploads/{unique_name}",
+            original_filename=upload.filename,
+            mime_type=upload.content_type or "application/octet-stream",
+            position=existing_count + index,
+        )
+        task.images.append(image)
+
+
+def _normalize_image_positions(task: Task) -> None:
+    for position, image in enumerate(sorted(task.images, key=lambda item: item.position)):
+        image.position = position
+
+
+def _mark_exam_as_active(db: Session, exam: ExamSession) -> None:
+    db.execute(update(ExamSession).values(is_active=False))
+    exam.is_active = True
+    db.flush()
+
+
+def _encode_task_image(image: TaskImage) -> Optional[dict]:
+    file_path = STATIC_DIR / image.file_path
+    if not file_path.exists():
+        return None
+    data = base64.b64encode(file_path.read_bytes()).decode("utf-8")
+    return {
+        "original_filename": image.original_filename,
+        "mime_type": image.mime_type,
+        "data": data,
+        "position": image.position,
+    }
+
+
+def _store_imported_image(data: dict) -> tuple[str, str, str]:
+    encoded = data.get("data")
+    if not encoded:
+        raise HTTPException(
+            status_code=400, detail="Bilddaten fehlen im Import."  # pragma: no cover
+        )
+    try:
+        content = base64.b64decode(encoded)
+    except (ValueError, TypeError) as exc:  # pragma: no cover
+        raise HTTPException(status_code=400, detail="Ungültige Bilddaten im Import.") from exc
+
+    original_filename = data.get("original_filename", "attachment")
+    mime_type = data.get("mime_type", "application/octet-stream")
+    suffix = _guess_file_suffix(original_filename, mime_type)
+    unique_name = f"{uuid4().hex}{suffix}"
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    destination = UPLOAD_DIR / unique_name
+    destination.write_bytes(content)
+    return unique_name, original_filename, mime_type
 @app.on_event("startup")
 async def on_startup() -> None:
     init_db()
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    with session_scope() as db:
+        _sync_category_nodes(db)
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -53,6 +243,7 @@ def index(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
         db.scalars(select(StudentGroup).order_by(StudentGroup.label)).unique().all()
     )
     category_requirements = db.scalars(select(CategoryRequirement).order_by(CategoryRequirement.category)).all()
+    requirements_map = {requirement.category: requirement for requirement in category_requirements}
     tasks_count = db.scalar(select(func.count()).select_from(Task)) or 0
     latest_exam = db.scalars(
         select(ExamSession)
@@ -60,6 +251,15 @@ def index(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
         .order_by(ExamSession.started_at.desc())
         .limit(1)
     ).unique().first()
+    category_tree = _get_category_tree(db)
+    active_exam = db.scalars(
+        select(ExamSession)
+        .options(joinedload(ExamSession.group))
+        .where(ExamSession.is_active.is_(True))
+        .order_by(ExamSession.started_at.desc())
+        .limit(1)
+    ).unique().first()
+    student_live_url = request.url_for("show_exam_live")
 
     return templates.TemplateResponse(
         "index.html",
@@ -67,8 +267,12 @@ def index(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
             "request": request,
             "groups": groups,
             "category_requirements": category_requirements,
+            "category_tree": category_tree,
+            "requirements_map": requirements_map,
             "tasks_count": tasks_count,
             "latest_exam": latest_exam,
+            "active_exam": active_exam,
+            "student_live_url": student_live_url,
         },
     )
 
@@ -105,7 +309,11 @@ async def import_students(
 @app.get("/tasks", response_class=HTMLResponse)
 def list_tasks(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
     tasks = (
-        db.scalars(select(Task).order_by(Task.category, Task.subcategory, Task.title))
+        db.scalars(
+            select(Task)
+            .options(joinedload(Task.dependencies), joinedload(Task.images))
+            .order_by(Task.category, Task.subcategory, Task.title)
+        )
         .unique()
         .all()
     )
@@ -118,21 +326,40 @@ def list_tasks(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
         }
         for task in tasks
     ]
+    import_summary = None
+    if request.query_params.get("import_status") == "success":
+        try:
+            import_summary = {
+                "tasks": int(request.query_params.get("tasks", "0")),
+                "categories": int(request.query_params.get("categories", "0")),
+                "subcategories": int(request.query_params.get("subcategories", "0")),
+                "images": int(request.query_params.get("images", "0")),
+            }
+        except ValueError:
+            import_summary = None
     return templates.TemplateResponse(
         "tasks_list.html",
-        {"request": request, "tasks": rendered_tasks},
+        {"request": request, "tasks": rendered_tasks, "import_summary": import_summary},
     )
 
 
 @app.get("/tasks/new", response_class=HTMLResponse)
 def new_task_form(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
     all_tasks = db.scalars(select(Task).order_by(Task.title)).unique().all()
+    categories = _get_category_tree(db)
+    category_options_json = json.dumps(
+        _serialize_category_options(categories), ensure_ascii=False
+    )
     return templates.TemplateResponse(
         "tasks_form.html",
         {
             "request": request,
             "task": None,
             "all_tasks": all_tasks,
+            "categories": categories,
+            "category_options_json": category_options_json,
+            "selected_category_id": None,
+            "selected_subcategory_id": None,
         },
     )
 
@@ -144,12 +371,23 @@ def edit_task_form(task_id: int, request: Request, db: Session = Depends(get_db)
         raise HTTPException(status_code=404, detail="Aufgabe nicht gefunden")
 
     all_tasks = db.scalars(select(Task).order_by(Task.title)).unique().all()
+    categories = _get_category_tree(db)
+    category_options_json = json.dumps(
+        _serialize_category_options(categories), ensure_ascii=False
+    )
+    selected_category_id, selected_subcategory_id = _get_category_selection_for_task(
+        db, task
+    )
     return templates.TemplateResponse(
         "tasks_form.html",
         {
             "request": request,
             "task": task,
             "all_tasks": all_tasks,
+            "categories": categories,
+            "category_options_json": category_options_json,
+            "selected_category_id": selected_category_id,
+            "selected_subcategory_id": selected_subcategory_id,
         },
     )
 
@@ -158,18 +396,23 @@ def edit_task_form(task_id: int, request: Request, db: Session = Depends(get_db)
 async def create_task(
     request: Request,
     title: str = Form(...),
-    category: str = Form(...),
-    subcategory: Optional[str] = Form(None),
+    category_id: int = Form(...),
+    subcategory_id: Optional[str] = Form(None),
     statement_markdown: str = Form(...),
     hints_markdown: Optional[str] = Form(None),
     solution_markdown: Optional[str] = Form(None),
     dependency_ids: Optional[str] = Form(None),
+    images: List[UploadFile] = File([]),
     db: Session = Depends(get_db),
 ) -> Response:
+    subcategory_pk = int(subcategory_id) if subcategory_id else None
+    category_node, subcategory_node = _resolve_category_selection(
+        db, category_id, subcategory_pk
+    )
     task = Task(
         title=title.strip(),
-        category=category.strip(),
-        subcategory=subcategory.strip() if subcategory else None,
+        category=category_node.name,
+        subcategory=subcategory_node.name if subcategory_node else None,
         statement_markdown=statement_markdown,
         hints_markdown=hints_markdown,
         solution_markdown=solution_markdown,
@@ -181,6 +424,8 @@ async def create_task(
         dependencies = _parse_dependency_ids(dependency_ids, db, task.id)
         task.dependencies = dependencies
 
+    await _save_uploaded_images(task, images)
+    _normalize_image_positions(task)
     db.commit()
     return RedirectResponse(url="/tasks", status_code=303)
 
@@ -190,21 +435,27 @@ async def update_task(
     task_id: int,
     request: Request,
     title: str = Form(...),
-    category: str = Form(...),
-    subcategory: Optional[str] = Form(None),
+    category_id: int = Form(...),
+    subcategory_id: Optional[str] = Form(None),
     statement_markdown: str = Form(...),
     hints_markdown: Optional[str] = Form(None),
     solution_markdown: Optional[str] = Form(None),
     dependency_ids: Optional[str] = Form(None),
+    remove_image_ids: List[str] = Form([]),
+    images: List[UploadFile] = File([]),
     db: Session = Depends(get_db),
 ) -> Response:
     task = db.get(Task, task_id)
     if not task:
         raise HTTPException(status_code=404, detail="Aufgabe nicht gefunden")
 
+    subcategory_pk = int(subcategory_id) if subcategory_id else None
+    category_node, subcategory_node = _resolve_category_selection(
+        db, category_id, subcategory_pk
+    )
     task.title = title.strip()
-    task.category = category.strip()
-    task.subcategory = subcategory.strip() if subcategory else None
+    task.category = category_node.name
+    task.subcategory = subcategory_node.name if subcategory_node else None
     task.statement_markdown = statement_markdown
     task.hints_markdown = hints_markdown
     task.solution_markdown = solution_markdown
@@ -212,8 +463,211 @@ async def update_task(
     if dependency_ids is not None:
         task.dependencies = _parse_dependency_ids(dependency_ids, db, task.id)
 
+    remove_ids: List[int] = []
+    for value in remove_image_ids or []:
+        try:
+            remove_ids.append(int(value))
+        except (TypeError, ValueError):
+            continue
+
+    for image in list(task.images):
+        if image.id in remove_ids:
+            _delete_image_file(image)
+            db.delete(image)
+
+    await _save_uploaded_images(task, images)
+    _normalize_image_positions(task)
+
     db.commit()
     return RedirectResponse(url="/tasks", status_code=303)
+
+
+@app.get("/tasks/export")
+def export_tasks_data(db: Session = Depends(get_db)) -> JSONResponse:
+    categories = _get_category_tree(db)
+    requirements = {
+        requirement.category: requirement.required_count
+        for requirement in db.scalars(select(CategoryRequirement)).all()
+    }
+    categories_payload = [
+        {
+            "name": category.name,
+            "required_count": requirements.get(category.name, 0),
+            "subcategories": [
+                {"name": subcategory.name} for subcategory in category.children
+            ],
+        }
+        for category in categories
+    ]
+
+    tasks = (
+        db.scalars(
+            select(Task)
+            .options(joinedload(Task.dependencies), joinedload(Task.images))
+            .order_by(Task.category, Task.subcategory, Task.title)
+        )
+        .unique()
+        .all()
+    )
+    tasks_payload = []
+    for task in tasks:
+        task_payload = {
+            "id": task.id,
+            "title": task.title,
+            "category": task.category,
+            "subcategory": task.subcategory,
+            "statement_markdown": task.statement_markdown,
+            "hints_markdown": task.hints_markdown,
+            "solution_markdown": task.solution_markdown,
+            "dependencies": [dependency.id for dependency in task.dependencies],
+        }
+        images_payload = []
+        for image in task.images:
+            encoded = _encode_task_image(image)
+            if encoded:
+                images_payload.append(encoded)
+        if images_payload:
+            task_payload["images"] = images_payload
+        tasks_payload.append(task_payload)
+
+    payload = {"categories": categories_payload, "tasks": tasks_payload}
+    headers = {
+        "Content-Disposition": "attachment; filename=examination_tasks_export.json"
+    }
+    return JSONResponse(payload, headers=headers)
+
+
+@app.post("/tasks/import")
+async def import_tasks_data(
+    upload: UploadFile = File(...),
+    db: Session = Depends(get_db),
+) -> Response:
+    if not upload.filename:
+        raise HTTPException(status_code=400, detail="Keine Datei hochgeladen.")
+    data = await upload.read()
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail="Ungültige JSON-Datei.") from exc
+
+    categories_data = payload.get("categories", []) or []
+    tasks_data = payload.get("tasks", []) or []
+
+    created_categories = 0
+    created_subcategories = 0
+    imported_images = 0
+
+    for category_entry in categories_data:
+        name = (category_entry.get("name") or "").strip()
+        if not name:
+            continue
+        required_count = int(category_entry.get("required_count", 0) or 0)
+        requirement = db.scalars(
+            select(CategoryRequirement).where(CategoryRequirement.category == name)
+        ).first()
+        if requirement:
+            requirement.required_count = required_count
+        else:
+            requirement = CategoryRequirement(category=name, required_count=required_count)
+            db.add(requirement)
+            created_categories += 1
+
+        category_node = db.scalars(
+            select(Category)
+            .where(Category.name == name)
+            .where(Category.parent_id.is_(None))
+        ).first()
+        if not category_node:
+            category_node = Category(name=name)
+            db.add(category_node)
+            db.flush()
+            created_categories += 1
+        else:
+            db.flush()
+
+        for sub_entry in category_entry.get("subcategories", []) or []:
+            sub_name = (sub_entry.get("name") or "").strip()
+            if not sub_name:
+                continue
+            existing_sub = db.scalars(
+                select(Category)
+                .where(Category.parent_id == category_node.id)
+                .where(Category.name == sub_name)
+            ).first()
+            if existing_sub:
+                continue
+            subcategory = Category(name=sub_name, parent=category_node)
+            db.add(subcategory)
+            created_subcategories += 1
+
+    db.flush()
+
+    id_mapping: dict[int, Task] = {}
+    for task_entry in tasks_data:
+        title = (task_entry.get("title") or "").strip()
+        if not title:
+            continue
+        statement_markdown = task_entry.get("statement_markdown") or ""
+        task = Task(
+            title=title,
+            category=(task_entry.get("category") or "").strip(),
+            subcategory=(task_entry.get("subcategory") or None),
+            statement_markdown=statement_markdown,
+            hints_markdown=task_entry.get("hints_markdown"),
+            solution_markdown=task_entry.get("solution_markdown"),
+        )
+        db.add(task)
+        db.flush()
+        original_id = task_entry.get("id")
+        if isinstance(original_id, int):
+            id_mapping[original_id] = task
+
+        images = task_entry.get("images", []) or []
+        for position, image_entry in enumerate(images):
+            try:
+                unique_name, original_filename, mime_type = _store_imported_image(
+                    image_entry
+                )
+            except HTTPException:
+                continue
+            image = TaskImage(
+                task=task,
+                file_path=f"uploads/{unique_name}",
+                original_filename=original_filename,
+                mime_type=mime_type,
+                position=image_entry.get("position", position),
+            )
+            db.add(image)
+            imported_images += 1
+        _normalize_image_positions(task)
+
+    db.flush()
+
+    for task_entry in tasks_data:
+        original_id = task_entry.get("id")
+        if not isinstance(original_id, int):
+            continue
+        task = id_mapping.get(original_id)
+        if not task:
+            continue
+        dependency_ids = task_entry.get("dependencies", []) or []
+        dependencies: List[Task] = []
+        for dep_id in dependency_ids:
+            mapped = id_mapping.get(dep_id)
+            if mapped and mapped.id != task.id:
+                dependencies.append(mapped)
+        task.dependencies = dependencies
+
+    db.commit()
+
+    params = (
+        "?import_status=success"
+        f"&tasks={len(tasks_data)}"
+        f"&categories={created_categories}"
+        f"&subcategories={created_subcategories}"
+        f"&images={imported_images}"
+    )
+    return RedirectResponse(url=f"/tasks{params}", status_code=303)
 
 
 @app.post("/tasks/{task_id}/delete")
@@ -221,6 +675,8 @@ def delete_task(task_id: int, db: Session = Depends(get_db)) -> Response:
     task = db.get(Task, task_id)
     if not task:
         raise HTTPException(status_code=404, detail="Aufgabe nicht gefunden")
+    for image in list(task.images):
+        _delete_image_file(image)
     db.delete(task)
     db.commit()
     return RedirectResponse(url="/tasks", status_code=303)
@@ -228,12 +684,20 @@ def delete_task(task_id: int, db: Session = Depends(get_db)) -> Response:
 
 @app.get("/categories", response_class=HTMLResponse)
 def list_categories(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
-    categories = (
-        db.scalars(select(CategoryRequirement).order_by(CategoryRequirement.category)).all()
-    )
+    requirements = {
+        requirement.category: requirement
+        for requirement in db.scalars(
+            select(CategoryRequirement).order_by(CategoryRequirement.category)
+        ).all()
+    }
+    categories = _get_category_tree(db)
     return templates.TemplateResponse(
         "categories.html",
-        {"request": request, "categories": categories},
+        {
+            "request": request,
+            "categories": categories,
+            "requirements": requirements,
+        },
     )
 
 
@@ -244,15 +708,32 @@ async def save_category(
     category_id: Optional[int] = Form(None),
     db: Session = Depends(get_db),
 ) -> Response:
+    category_name = category.strip()
     if category_id:
         requirement = db.get(CategoryRequirement, category_id)
         if not requirement:
             raise HTTPException(status_code=404, detail="Kategorie nicht gefunden")
-        requirement.category = category.strip()
+        requirement.category = category_name
         requirement.required_count = required_count
+        category_node = db.scalars(
+            select(Category)
+            .where(Category.name == category_name)
+            .where(Category.parent_id.is_(None))
+        ).first()
+        if not category_node:
+            db.add(Category(name=category_name))
     else:
-        requirement = CategoryRequirement(category=category.strip(), required_count=required_count)
+        requirement = CategoryRequirement(
+            category=category_name, required_count=required_count
+        )
         db.add(requirement)
+        existing = db.scalars(
+            select(Category)
+            .where(Category.name == category_name)
+            .where(Category.parent_id.is_(None))
+        ).first()
+        if not existing:
+            db.add(Category(name=category_name))
 
     db.commit()
     return RedirectResponse(url="/categories", status_code=303)
@@ -263,7 +744,77 @@ def delete_category(category_id: int, db: Session = Depends(get_db)) -> Response
     requirement = db.get(CategoryRequirement, category_id)
     if not requirement:
         raise HTTPException(status_code=404, detail="Kategorie nicht gefunden")
+    tasks_in_category = db.scalar(
+        select(func.count())
+        .select_from(Task)
+        .where(Task.category == requirement.category)
+    )
+    if tasks_in_category:
+        raise HTTPException(
+            status_code=400,
+            detail="Kategorie kann nicht gelöscht werden, solange ihr Aufgaben zugeordnet sind.",
+        )
+    category_node = db.scalars(
+        select(Category)
+        .where(Category.name == requirement.category)
+        .where(Category.parent_id.is_(None))
+    ).first()
+    if category_node:
+        db.delete(category_node)
     db.delete(requirement)
+    db.commit()
+    return RedirectResponse(url="/categories", status_code=303)
+
+
+@app.post("/categories/{category_id}/subcategories")
+async def add_subcategory(
+    category_id: int,
+    name: str = Form(...),
+    db: Session = Depends(get_db),
+) -> Response:
+    parent = db.get(Category, category_id)
+    if not parent or parent.parent_id is not None:
+        raise HTTPException(status_code=404, detail="Kategorie nicht gefunden")
+    subcategory_name = name.strip()
+    if not subcategory_name:
+        raise HTTPException(status_code=400, detail="Unterkategorie benötigt einen Namen.")
+    existing = db.scalars(
+        select(Category)
+        .where(Category.parent_id == parent.id)
+        .where(Category.name == subcategory_name)
+    ).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Unterkategorie existiert bereits.")
+
+    subcategory = Category(name=subcategory_name, parent=parent)
+    db.add(subcategory)
+    db.commit()
+    return RedirectResponse(url="/categories", status_code=303)
+
+
+@app.post("/categories/{category_id}/subcategories/{subcategory_id}/delete")
+def delete_subcategory(
+    category_id: int,
+    subcategory_id: int,
+    db: Session = Depends(get_db),
+) -> Response:
+    parent = db.get(Category, category_id)
+    if not parent or parent.parent_id is not None:
+        raise HTTPException(status_code=404, detail="Kategorie nicht gefunden")
+    subcategory = db.get(Category, subcategory_id)
+    if not subcategory or subcategory.parent_id != parent.id:
+        raise HTTPException(status_code=404, detail="Unterkategorie nicht gefunden")
+
+    db.delete(subcategory)
+    db.flush()
+    tasks_to_update = db.scalars(
+        select(Task)
+        .where(Task.category == parent.name)
+        .where(Task.subcategory == subcategory.name)
+    ).all()
+    for task in tasks_to_update:
+        task.subcategory = None
+
     db.commit()
     return RedirectResponse(url="/categories", status_code=303)
 
@@ -272,6 +823,7 @@ def delete_category(category_id: int, db: Session = Depends(get_db)) -> Response
 def create_exam(group_id: int = Form(...), db: Session = Depends(get_db)) -> Response:
     try:
         exam = generate_exam_for_group(db, group_id)
+        _mark_exam_as_active(db, exam)
         db.commit()
     except ExamGenerationError as exc:
         db.rollback()
@@ -287,6 +839,7 @@ def create_exam(group_id: int = Form(...), db: Session = Depends(get_db)) -> Res
 def regenerate_exam_tasks(exam_id: int, db: Session = Depends(get_db)) -> Response:
     try:
         exam = regenerate_exam(db, exam_id)
+        _mark_exam_as_active(db, exam)
         db.commit()
     except ExamGenerationError as exc:
         db.rollback()
@@ -303,7 +856,11 @@ def show_exam_teacher(exam_id: int, request: Request, db: Session = Depends(get_
     exam = db.scalars(
         select(ExamSession)
         .options(joinedload(ExamSession.group).joinedload(StudentGroup.students))
-        .options(joinedload(ExamSession.assignments).joinedload(ExamTaskAssignment.task))
+        .options(
+            joinedload(ExamSession.assignments).joinedload(ExamTaskAssignment.task).joinedload(
+                Task.images
+            )
+        )
         .where(ExamSession.id == exam_id)
     ).unique().first()
     if not exam:
@@ -323,7 +880,15 @@ def show_exam_student(exam_id: int, request: Request, db: Session = Depends(get_
         raise HTTPException(status_code=404, detail="Prüfungssitzung nicht gefunden")
     return templates.TemplateResponse(
         "exam_student.html",
-        {"request": request, "exam_id": exam_id},
+        {"request": request, "exam_id": exam_id, "live_mode": False},
+    )
+
+
+@app.get("/exams/live", response_class=HTMLResponse, name="show_exam_live")
+def show_exam_live(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse(
+        "exam_student.html",
+        {"request": request, "exam_id": None, "live_mode": True},
     )
 
 
@@ -336,13 +901,43 @@ def get_exam_data(
     exam = db.scalars(
         select(ExamSession)
         .options(joinedload(ExamSession.group).joinedload(StudentGroup.students))
-        .options(joinedload(ExamSession.assignments).joinedload(ExamTaskAssignment.task))
+        .options(
+            joinedload(ExamSession.assignments).joinedload(ExamTaskAssignment.task).joinedload(
+                Task.images
+            )
+        )
         .where(ExamSession.id == exam_id)
     ).unique().first()
     if not exam:
         raise HTTPException(status_code=404, detail="Prüfungssitzung nicht gefunden")
     payload = build_exam_payload(exam, include_solutions=include_solutions)
     return JSONResponse(payload)
+
+
+@app.get("/api/exams/active", response_class=JSONResponse)
+def get_active_exam(db: Session = Depends(get_db)) -> JSONResponse:
+    exam = db.scalars(
+        select(ExamSession)
+        .options(joinedload(ExamSession.group).joinedload(StudentGroup.students))
+        .options(
+            joinedload(ExamSession.assignments).joinedload(ExamTaskAssignment.task).joinedload(
+                Task.images
+            )
+        )
+        .where(ExamSession.is_active.is_(True))
+        .order_by(ExamSession.started_at.desc())
+        .limit(1)
+    ).unique().first()
+    if not exam:
+        raise HTTPException(status_code=404, detail="Aktuell ist keine Prüfung aktiv.")
+    payload = build_exam_payload(exam, include_solutions=False)
+    return JSONResponse(payload)
+
+
+@app.post("/api/markdown/preview", response_class=JSONResponse)
+async def markdown_preview(payload: MarkdownPreviewRequest) -> JSONResponse:
+    html = render_markdown(payload.content) or ""
+    return JSONResponse({"html": html})
 
 
 def _parse_dependency_ids(raw_value: str, db: Session, current_task_id: Optional[int]) -> List[Task]:

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -83,6 +83,7 @@ class ExamTaskOut(BaseModel):
     hints_html: Optional[str]
     solution_html: Optional[str]
     position: int
+    image_urls: List[str] = []
 
 
 class ExamSessionOut(BaseModel):
@@ -90,4 +91,8 @@ class ExamSessionOut(BaseModel):
     group: StudentGroupRead
     tasks: List[ExamTaskOut]
     started_at: datetime
+
+
+class MarkdownPreviewRequest(BaseModel):
+    content: str
 

--- a/app/services/exam_service.py
+++ b/app/services/exam_service.py
@@ -99,7 +99,14 @@ def generate_exam_for_group(db: Session, group_id: int, rng: random.Random | Non
         raise ExamGenerationError("Es wurden noch keine Kategorienanforderungen definiert.")
 
     tasks = (
-        db.scalars(select(Task).options(joinedload(Task.dependencies))).unique().all()
+        db.scalars(
+            select(Task).options(
+                joinedload(Task.dependencies),
+                joinedload(Task.images),
+            )
+        )
+        .unique()
+        .all()
     )
     tasks_by_category = _collect_tasks_by_category(tasks)
 
@@ -121,7 +128,14 @@ def regenerate_exam(db: Session, exam_id: int, rng: random.Random | None = None)
 
     requirements = db.scalars(select(CategoryRequirement)).all()
     tasks = (
-        db.scalars(select(Task).options(joinedload(Task.dependencies))).unique().all()
+        db.scalars(
+            select(Task).options(
+                joinedload(Task.dependencies),
+                joinedload(Task.images),
+            )
+        )
+        .unique()
+        .all()
     )
     tasks_by_category = _collect_tasks_by_category(tasks)
     selected_tasks = _choose_tasks_for_requirements(requirements, tasks_by_category, rng)
@@ -146,6 +160,7 @@ def build_exam_payload(exam: ExamSession, include_solutions: bool) -> dict:
                 if include_solutions
                 else None,
                 "position": assignment.position,
+                "image_urls": [f"/static/{image.file_path}" for image in task.images],
             }
         )
 

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -212,3 +212,181 @@ textarea {
     gap: 0.5rem;
   }
 }
+
+.markdown-editor-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.markdown-editor textarea {
+  min-height: 220px;
+}
+
+.markdown-preview {
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: #f9fafb;
+  padding: 0.75rem;
+  min-height: 220px;
+  overflow-y: auto;
+}
+
+.task-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.task-toolbar-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+#task-import-form {
+  position: relative;
+}
+
+#task-import-form input[type='file'] {
+  display: none;
+}
+
+.task-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.task-images figure {
+  margin: 0;
+}
+
+.task-images img {
+  max-width: 220px;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  display: block;
+}
+
+.task-images figcaption {
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.image-gallery {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.image-gallery-item {
+  background: #f9fafb;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  text-align: center;
+  max-width: 220px;
+}
+
+.image-gallery-item img {
+  max-width: 100%;
+  border-radius: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.remove-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.share-link {
+  font-family: 'Fira Code', 'Courier New', monospace;
+  background: #eef2ff;
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.5rem;
+  display: inline-block;
+  word-break: break-all;
+}
+
+.category-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.category-card {
+  background: #f9fafb;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.category-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.category-card header form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-end;
+}
+
+.category-card header form input[type='number'] {
+  width: 5rem;
+}
+
+.subcategory-list ul {
+  list-style: disc;
+  padding-left: 1.25rem;
+}
+
+.subcategory-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.35rem;
+}
+
+.add-subcategory-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.delete-category-form {
+  margin-top: auto;
+}
+
+.category-summary {
+  list-style: none;
+  padding-left: 0;
+}
+
+.category-summary > li {
+  margin-bottom: 0.5rem;
+}
+
+.category-summary ul {
+  list-style: disc;
+  margin-left: 1.25rem;
+  margin-top: 0.25rem;
+}

--- a/app/static/uploads/.gitignore
+++ b/app/static/uploads/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/app/templates/categories.html
+++ b/app/templates/categories.html
@@ -5,7 +5,7 @@
 {% block content %}
   <section class="card">
     <h2>Kategorien verwalten</h2>
-    <p>Lege fest, wie viele Aufgaben pro Kategorie zufällig ausgewählt werden. Jede Kategorie kann beliebig viele Aufgaben umfassen.</p>
+    <p>Lege fest, wie viele Aufgaben pro Kategorie zufällig ausgewählt werden, und verwalte passende Unterkategorien.</p>
     <form method="post" action="/categories" style="margin-bottom:1.5rem;">
       <h3>Neue Kategorie hinzufügen</h3>
       <div class="form-row">
@@ -22,35 +22,69 @@
     {% if not categories %}
       <p>Noch keine Kategorien angelegt.</p>
     {% else %}
-      <table class="table">
-        <thead>
-          <tr>
-            <th>Kategorie</th>
-            <th>Aufgabenanzahl</th>
-            <th>Aktionen</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for category in categories %}
-            <tr>
-              <td>{{ category.category }}</td>
-              <td>
+      <div class="category-grid">
+        {% for category in categories %}
+          {% set requirement = requirements.get(category.name) %}
+          <article class="category-card">
+            <header>
+              <h3>{{ category.name }}</h3>
+              {% if requirement %}
                 <form method="post" action="/categories">
-                  <input type="hidden" name="category_id" value="{{ category.id }}" />
-                  <input type="hidden" name="category" value="{{ category.category }}" />
-                  <input type="number" name="required_count" value="{{ category.required_count }}" min="1" required />
+                  <input type="hidden" name="category_id" value="{{ requirement.id }}" />
+                  <input type="hidden" name="category" value="{{ requirement.category }}" />
+                  <label>
+                    Aufgaben pro Prüfung
+                    <input type="number" name="required_count" value="{{ requirement.required_count }}" min="1" required />
+                  </label>
                   <button type="submit" class="secondary">Speichern</button>
                 </form>
-              </td>
-              <td>
-                <form method="post" action="/categories/{{ category.id }}/delete" onsubmit="return confirm('Kategorie wirklich löschen?');">
-                  <button type="submit" class="danger">Löschen</button>
-                </form>
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+              {% endif %}
+            </header>
+            <div class="subcategory-list">
+              <h4>Unterkategorien</h4>
+              {% if not category.children %}
+                <p class="task-metadata">Noch keine Unterkategorien angelegt.</p>
+              {% else %}
+                <ul>
+                  {% for subcategory in category.children %}
+                    <li>
+                      {{ subcategory.name }}
+                      <form
+                        method="post"
+                        action="/categories/{{ category.id }}/subcategories/{{ subcategory.id }}/delete"
+                        onsubmit="return confirm('Unterkategorie wirklich löschen?');"
+                      >
+                        <button type="submit" class="danger">Löschen</button>
+                      </form>
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+              <form method="post" action="/categories/{{ category.id }}/subcategories" class="add-subcategory-form">
+                <label for="new-subcategory-{{ category.id }}">Neue Unterkategorie</label>
+                <input
+                  id="new-subcategory-{{ category.id }}"
+                  type="text"
+                  name="name"
+                  placeholder="Bezeichnung"
+                  required
+                />
+                <button type="submit" class="secondary">Hinzufügen</button>
+              </form>
+            </div>
+            {% if requirement %}
+              <form
+                method="post"
+                action="/categories/{{ requirement.id }}/delete"
+                onsubmit="return confirm('Kategorie wirklich löschen? Alle Unterkategorien werden entfernt.');"
+                class="delete-category-form"
+              >
+                <button type="submit" class="danger">Kategorie löschen</button>
+              </form>
+            {% endif %}
+          </article>
+        {% endfor %}
+      </div>
     {% endif %}
   </section>
 {% endblock %}

--- a/app/templates/exam_student.html
+++ b/app/templates/exam_student.html
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block content %}
-  <section class="card" id="student-app" data-exam-id="{{ exam_id }}">
+  <section class="card" id="student-app" data-exam-id="{{ exam_id if exam_id else '' }}" data-live="{{ 'true' if live_mode else 'false' }}">
     <h2 id="group-label">Prüfung</h2>
     <div class="task-metadata">Diese Ansicht blendet Hinweise und Lösungen automatisch aus.</div>
     <div id="tasks" class="exam-layout" style="margin-top:1.5rem;">
@@ -27,15 +27,28 @@
     const tasksContainer = document.getElementById('tasks');
     const groupLabel = document.getElementById('group-label');
     const examId = appElement.dataset.examId;
+    const isLive = appElement.dataset.live === 'true';
 
     async function fetchExam() {
       try {
-        const response = await fetch(`/api/exams/${examId}`);
+        const endpoint = isLive && !appElement.dataset.examId
+          ? '/api/exams/active'
+          : `/api/exams/${appElement.dataset.examId || examId}`;
+        const response = await fetch(endpoint);
         if (!response.ok) {
+          if (response.status === 404 && isLive) {
+            groupLabel.textContent = 'Prüfung';
+            tasksContainer.innerHTML = '<p class="task-metadata">Aktuell ist keine Prüfung aktiv.</p>';
+            appElement.dataset.examId = '';
+            return;
+          }
           throw new Error('Fehler beim Laden der Aufgaben');
         }
         const payload = await response.json();
         renderExam(payload);
+        if (isLive) {
+          appElement.dataset.examId = payload.exam_id;
+        }
       } catch (error) {
         tasksContainer.innerHTML = `<p class="alert error">${error.message}</p>`;
       }
@@ -53,6 +66,13 @@
             <h2>${index + 1}. ${task.title}</h2>
             <div class="task-metadata">${task.category}${task.subcategory ? ' · ' + task.subcategory : ''}</div>
             <div class="markdown">${task.statement_html}</div>
+            ${task.image_urls && task.image_urls.length ? `
+              <div class="task-images">
+                ${task.image_urls
+                  .map((url, imageIndex) => `<figure><img src="${url}" alt="Aufgabenbild ${imageIndex + 1}" /></figure>`)
+                  .join('')}
+              </div>
+            ` : ''}
           </article>
         `)
         .join('');

--- a/app/templates/exam_teacher.html
+++ b/app/templates/exam_teacher.html
@@ -15,8 +15,9 @@
         </div>
         <div class="task-metadata">Gestartet am {{ exam.started_at.strftime('%d.%m.%Y %H:%M') }} Uhr</div>
       </div>
-      <div style="display:flex; gap:0.5rem;">
-        <a class="button secondary" target="_blank" href="/exams/{{ exam.exam_id }}/student">Studierendenansicht öffnen</a>
+      <div style="display:flex; flex-direction:column; gap:0.5rem; align-items:flex-end;">
+        <a class="button secondary" target="_blank" href="{{ request.url_for('show_exam_live') }}">Studierendenansicht öffnen</a>
+        <span class="task-metadata">Link teilen: <code class="share-link">{{ request.url_for('show_exam_live') }}</code></span>
         <form method="post" action="/exams/{{ exam.exam_id }}/regenerate" onsubmit="return confirm('Aufgaben neu auslosen?');">
           <button type="submit">Neue Aufgaben auslosen</button>
         </form>
@@ -28,6 +29,15 @@
           <h2>{{ loop.index }}. {{ task.title }}</h2>
           <div class="task-metadata">{{ task.category }}{% if task.subcategory %} · {{ task.subcategory }}{% endif %}</div>
           <div class="markdown">{{ task.statement_html | safe }}</div>
+          {% if task.image_urls %}
+            <div class="task-images">
+              {% for image_url in task.image_urls %}
+                <figure>
+                  <img src="{{ image_url }}" alt="Aufgabenbild {{ loop.index }}" />
+                </figure>
+              {% endfor %}
+            </div>
+          {% endif %}
           {% if task.hints_html %}
             <div class="section-title">Hinweise</div>
             <div class="markdown">{{ task.hints_html | safe }}</div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -59,13 +59,40 @@
   </section>
 
   <section class="card">
+    <h2>Studierendenansicht</h2>
+    <p>Nutze diesen Link, um die Ansicht für Studierende auf einem separaten Bildschirm anzuzeigen. Bei neuen Prüfungen aktualisiert sich die Ansicht automatisch.</p>
+    <code class="share-link">{{ student_live_url }}</code>
+    <div class="task-metadata" style="margin-top:0.5rem;">
+      {% if active_exam %}
+        Aktive Prüfung: {{ active_exam.group.label }} (gestartet am {{ active_exam.started_at.strftime('%d.%m.%Y %H:%M') }} Uhr)
+      {% else %}
+        Aktuell ist keine Prüfung aktiv.
+      {% endif %}
+    </div>
+    <a class="button secondary" href="{{ student_live_url }}" target="_blank">Studierendenansicht öffnen</a>
+  </section>
+
+  <section class="card">
     <h2>Kategorien</h2>
-    {% if not category_requirements %}
+    {% if not category_tree %}
       <p>Definiere Kategorien, um die Auswahl der Aufgaben zu steuern.</p>
     {% else %}
-      <ul>
-        {% for category in category_requirements %}
-          <li><strong>{{ category.category }}</strong>: {{ category.required_count }} Aufgabe(n)</li>
+      <ul class="category-summary">
+        {% for category in category_tree %}
+          {% set requirement = requirements_map.get(category.name) %}
+          <li>
+            <strong>{{ category.name }}</strong>
+            {% if requirement %}
+              · {{ requirement.required_count }} Aufgabe(n)
+            {% endif %}
+            {% if category.children %}
+              <ul>
+                {% for subcategory in category.children %}
+                  <li>{{ subcategory.name }}</li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </li>
         {% endfor %}
       </ul>
     {% endif %}

--- a/app/templates/tasks_form.html
+++ b/app/templates/tasks_form.html
@@ -11,36 +11,115 @@
 {% block content %}
   <section class="card">
     <h2>{{ page_title }}</h2>
-    <form method="post" action="{% if task %}/tasks/{{ task.id }}{% else %}/tasks{% endif %}">
+    {% if not categories %}
+      <p class="alert warning">
+        Es wurden noch keine Kategorien definiert. Lege zunächst Kategorien an, bevor du Aufgaben erstellst.
+      </p>
+    {% endif %}
+    <form
+      id="task-form"
+      method="post"
+      enctype="multipart/form-data"
+      action="{% if task %}/tasks/{{ task.id }}{% else %}/tasks{% endif %}"
+    >
       <div class="form-row">
         <label for="title">Titel</label>
         <input id="title" type="text" name="title" value="{{ task.title if task else '' }}" required />
       </div>
       <div class="form-row">
-        <label for="category">Kategorie</label>
-        <input id="category" type="text" name="category" value="{{ task.category if task else '' }}" required />
+        <label for="category_id">Kategorie</label>
+        <select id="category_id" name="category_id" required>
+          <option value="" disabled {% if not selected_category_id %}selected{% endif %}>Kategorie wählen</option>
+          {% for category in categories %}
+            <option value="{{ category.id }}" {% if selected_category_id == category.id %}selected{% endif %}>{{ category.name }}</option>
+          {% endfor %}
+        </select>
       </div>
       <div class="form-row">
-        <label for="subcategory">Unterkategorie</label>
-        <input id="subcategory" type="text" name="subcategory" value="{{ task.subcategory if task and task.subcategory else '' }}" />
+        <label for="subcategory_id">Unterkategorie</label>
+        <select
+          id="subcategory_id"
+          name="subcategory_id"
+          data-selected="{{ selected_subcategory_id if selected_subcategory_id else '' }}"
+        >
+          <option value="" {% if not selected_subcategory_id %}selected{% endif %}>Keine Unterkategorie</option>
+          {% if selected_category_id %}
+            {% for category in categories %}
+              {% if category.id == selected_category_id %}
+                {% for subcategory in category.children %}
+                  <option value="{{ subcategory.id }}" {% if selected_subcategory_id == subcategory.id %}selected{% endif %}>{{ subcategory.name }}</option>
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+        </select>
       </div>
-      <div class="form-row">
+      <div class="form-row markdown-editor">
         <label for="statement_markdown">Aufgabe (Markdown)</label>
-        <textarea id="statement_markdown" name="statement_markdown" required>{{ task.statement_markdown if task else '' }}</textarea>
+        <div class="markdown-editor-grid">
+          <textarea
+            id="statement_markdown"
+            name="statement_markdown"
+            data-preview-target="statement-preview"
+            required
+          >{{ task.statement_markdown if task else '' }}</textarea>
+          <div class="markdown-preview" id="statement-preview"></div>
+        </div>
       </div>
-      <div class="form-row">
+      <div class="form-row markdown-editor">
         <label for="hints_markdown">Hinweise (Markdown, optional)</label>
-        <textarea id="hints_markdown" name="hints_markdown">{{ task.hints_markdown if task and task.hints_markdown else '' }}</textarea>
+        <div class="markdown-editor-grid">
+          <textarea
+            id="hints_markdown"
+            name="hints_markdown"
+            data-preview-target="hints-preview"
+          >{{ task.hints_markdown if task and task.hints_markdown else '' }}</textarea>
+          <div class="markdown-preview" id="hints-preview"></div>
+        </div>
       </div>
-      <div class="form-row">
+      <div class="form-row markdown-editor">
         <label for="solution_markdown">Lösung (Markdown, optional)</label>
-        <textarea id="solution_markdown" name="solution_markdown">{{ task.solution_markdown if task and task.solution_markdown else '' }}</textarea>
+        <div class="markdown-editor-grid">
+          <textarea
+            id="solution_markdown"
+            name="solution_markdown"
+            data-preview-target="solution-preview"
+          >{{ task.solution_markdown if task and task.solution_markdown else '' }}</textarea>
+          <div class="markdown-preview" id="solution-preview"></div>
+        </div>
       </div>
       <div class="form-row">
         <label for="dependency_ids">Abhängigkeiten (IDs, durch Komma getrennt)</label>
-        <input id="dependency_ids" type="text" name="dependency_ids" value="{% if task and task.dependencies %}{% for dep in task.dependencies %}{{ dep.id }}{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}" />
+        <input
+          id="dependency_ids"
+          type="text"
+          name="dependency_ids"
+          value="{% if task and task.dependencies %}{% for dep in task.dependencies %}{{ dep.id }}{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}"
+        />
         <small class="task-metadata">Wähle IDs aus der folgenden Liste, falls die Aufgabe von anderen Aufgaben abhängig ist.</small>
       </div>
+      <div class="form-row">
+        <label for="images">Anhänge (Bilder)</label>
+        <input id="images" type="file" name="images" accept="image/*" multiple />
+        <small class="task-metadata">Unterstützt PNG, JPG und andere gängige Bildformate. Mehrere Dateien können gleichzeitig ausgewählt werden.</small>
+      </div>
+      {% if task and task.images %}
+        <div class="form-row">
+          <label>Vorhandene Bilder</label>
+          <div class="image-gallery">
+            {% for image in task.images %}
+              <div class="image-gallery-item">
+                <img src="{{ url_for('static', path=image.file_path) }}" alt="{{ image.original_filename }}" />
+                <label class="remove-toggle">
+                  <input type="checkbox" name="remove_image_ids" value="{{ image.id }}" />
+                  Entfernen
+                </label>
+                <div class="task-metadata">{{ image.original_filename }}</div>
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
       {% if all_tasks %}
         <div class="form-row">
           <label>Verfügbare Aufgaben</label>
@@ -55,4 +134,103 @@
       <a class="button secondary" href="/tasks">Abbrechen</a>
     </form>
   </section>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    const categoryOptions = {{ category_options_json | safe }};
+    const categorySelect = document.getElementById('category_id');
+    const subcategorySelect = document.getElementById('subcategory_id');
+
+    function populateSubcategories(selectedCategoryId) {
+      const currentSelection = subcategorySelect.dataset.selected || '';
+      subcategorySelect.innerHTML = '';
+      const defaultOption = document.createElement('option');
+      defaultOption.value = '';
+      defaultOption.textContent = 'Keine Unterkategorie';
+      if (!currentSelection) {
+        defaultOption.selected = true;
+      }
+      subcategorySelect.appendChild(defaultOption);
+
+      const category = categoryOptions.find((entry) => entry.id === Number(selectedCategoryId));
+      if (!category) {
+        subcategorySelect.dataset.selected = '';
+        return;
+      }
+
+      category.subcategories.forEach((subcategory) => {
+        const option = document.createElement('option');
+        option.value = String(subcategory.id);
+        option.textContent = subcategory.name;
+        if (Number(currentSelection) === subcategory.id) {
+          option.selected = true;
+        }
+        subcategorySelect.appendChild(option);
+      });
+    }
+
+    if (categorySelect) {
+      categorySelect.addEventListener('change', (event) => {
+        subcategorySelect.dataset.selected = '';
+        populateSubcategories(event.target.value);
+      });
+
+      if (categorySelect.value) {
+        populateSubcategories(categorySelect.value);
+      }
+    }
+
+    function setupMarkdownPreview(textarea) {
+      const previewId = textarea.dataset.previewTarget;
+      const previewElement = document.getElementById(previewId);
+      if (!previewElement) {
+        return;
+      }
+
+      let timeoutId = null;
+      let abortController = null;
+
+      async function renderPreview() {
+        const content = textarea.value;
+        if (abortController) {
+          abortController.abort();
+        }
+        abortController = new AbortController();
+        try {
+          const response = await fetch('/api/markdown/preview', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ content }),
+            signal: abortController.signal,
+          });
+          if (!response.ok) {
+            throw new Error('Fehler bei der Vorschau');
+          }
+          const payload = await response.json();
+          previewElement.innerHTML = payload.html || '';
+          if (window.MathJax && window.MathJax.typesetPromise) {
+            window.MathJax.typesetPromise([previewElement]);
+          }
+        } catch (error) {
+          if (error.name === 'AbortError') {
+            return;
+          }
+          previewElement.innerHTML = '<p class="task-metadata">Keine Vorschau verfügbar.</p>';
+        }
+      }
+
+      const scheduleRender = () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        timeoutId = setTimeout(renderPreview, 250);
+      };
+
+      textarea.addEventListener('input', scheduleRender);
+      renderPreview();
+    }
+
+    document.querySelectorAll('.markdown-editor textarea').forEach(setupMarkdownPreview);
+  </script>
 {% endblock %}

--- a/app/templates/tasks_list.html
+++ b/app/templates/tasks_list.html
@@ -4,10 +4,24 @@
 
 {% block content %}
   <section class="card">
-    <div style="display:flex; justify-content:space-between; align-items:center;">
+    <div class="task-toolbar">
       <h2>Aufgaben</h2>
-      <a class="button" href="/tasks/new">Neue Aufgabe</a>
+      <div class="task-toolbar-actions">
+        <a class="button" href="/tasks/new">Neue Aufgabe</a>
+        <a class="button secondary" href="/tasks/export">JSON exportieren</a>
+        <form id="task-import-form" method="post" action="/tasks/import" enctype="multipart/form-data">
+          <label for="import-file" class="button secondary">JSON importieren</label>
+          <input id="import-file" type="file" name="upload" accept="application/json" required />
+        </form>
+      </div>
     </div>
+    {% if import_summary %}
+      <p class="alert success">
+        Import abgeschlossen:
+        {{ import_summary.tasks }} Aufgabe(n), {{ import_summary.categories }} Kategorie(n),
+        {{ import_summary.subcategories }} Unterkategorie(n) und {{ import_summary.images }} Bild(er) verarbeitet.
+      </p>
+    {% endif %}
     {% if not tasks %}
       <p>Noch keine Aufgaben vorhanden. Lege die erste Aufgabe an, um Prüfungen erstellen zu können.</p>
     {% else %}
@@ -21,6 +35,16 @@
           <div class="task-body">
             <h4 class="section-title">Aufgabe</h4>
             <div class="markdown">{{ item.statement_html | safe }}</div>
+            {% if task.images %}
+              <div class="task-images">
+                {% for image in task.images %}
+                  <figure>
+                    <img src="{{ url_for('static', path=image.file_path) }}" alt="{{ image.original_filename }}" />
+                    <figcaption>{{ image.original_filename }}</figcaption>
+                  </figure>
+                {% endfor %}
+              </div>
+            {% endif %}
             {% if item.hints_html %}
               <h4 class="section-title">Hinweise</h4>
               <div class="markdown">{{ item.hints_html | safe }}</div>
@@ -43,4 +67,17 @@
       {% endfor %}
     {% endif %}
   </section>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    const importInput = document.getElementById('import-file');
+    if (importInput) {
+      importInput.addEventListener('change', () => {
+        if (importInput.files.length) {
+          importInput.form.submit();
+        }
+      });
+    }
+  </script>
 {% endblock %}

--- a/tests/test_exam_generation.py
+++ b/tests/test_exam_generation.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+import base64
+import json
 import random
 import sys
 from io import BytesIO
@@ -9,13 +12,15 @@ import pandas as pd
 import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
+from starlette.datastructures import UploadFile
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
 
 from app.db import Base
-from app.models import CategoryRequirement, Student, StudentGroup, Task
+from app.main import UPLOAD_DIR, export_tasks_data, import_tasks_data
+from app.models import Category, CategoryRequirement, Student, StudentGroup, Task, TaskImage
 from app.services.exam_service import ExamGenerationError, generate_exam_for_group
 from app.services.student_import_service import import_students_from_excel
 
@@ -105,3 +110,124 @@ def test_import_students_from_excel(session: Session) -> None:
     groups = session.scalars(select(StudentGroup)).unique().all()
     assert len(groups) == 1
     assert sorted(student.full_name for student in groups[0].students) == ["Anna", "Bernd"]
+
+
+def test_export_tasks_includes_categories_and_images(session: Session) -> None:
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    image_path = UPLOAD_DIR / "test_export_image.png"
+    image_bytes = b"test-image"
+    image_path.write_bytes(image_bytes)
+
+    category = Category(name="Analysis")
+    subcategory = Category(name="Differential", parent=category)
+    session.add_all([category, subcategory])
+    session.add(CategoryRequirement(category="Analysis", required_count=2))
+
+    prerequisite = Task(
+        title="Vorkurs",
+        category="Analysis",
+        subcategory=None,
+        statement_markdown="Vorbereitung",
+    )
+    task = Task(
+        title="Analysis Hauptaufgabe",
+        category="Analysis",
+        subcategory="Differential",
+        statement_markdown="**Inhalt**",
+    )
+    session.add_all([prerequisite, task])
+    session.commit()
+
+    task.dependencies.append(prerequisite)
+    session.add(
+        TaskImage(
+            task_id=task.id,
+            file_path=f"uploads/{image_path.name}",
+            original_filename="grafik.png",
+            mime_type="image/png",
+            position=0,
+        )
+    )
+    session.commit()
+
+    response = export_tasks_data(db=session)
+    payload = json.loads(response.body)
+
+    assert payload["categories"]
+    exported_category = payload["categories"][0]
+    assert exported_category["name"] == "Analysis"
+    assert exported_category["subcategories"][0]["name"] == "Differential"
+
+    exported_tasks = {item["title"]: item for item in payload["tasks"]}
+    assert "Analysis Hauptaufgabe" in exported_tasks
+    main_task = exported_tasks["Analysis Hauptaufgabe"]
+    assert main_task["dependencies"] == [prerequisite.id]
+    assert main_task["images"]
+    encoded_image = main_task["images"][0]["data"]
+    assert base64.b64decode(encoded_image) == image_bytes
+
+    image_path.unlink(missing_ok=True)
+
+
+def test_import_tasks_creates_records(session: Session) -> None:
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    image_bytes = b"import-image"
+    payload = {
+        "categories": [
+            {
+                "name": "Analysis",
+                "required_count": 2,
+                "subcategories": [{"name": "Differential"}],
+            }
+        ],
+        "tasks": [
+            {
+                "id": 1,
+                "title": "Analysis Aufgabe",
+                "category": "Analysis",
+                "subcategory": "Differential",
+                "statement_markdown": "Aufgabe",
+                "dependencies": [2],
+                "images": [
+                    {
+                        "original_filename": "bild.png",
+                        "mime_type": "image/png",
+                        "position": 0,
+                        "data": base64.b64encode(image_bytes).decode("utf-8"),
+                    }
+                ],
+            },
+            {
+                "id": 2,
+                "title": "Grundaufgabe",
+                "category": "Analysis",
+                "subcategory": None,
+                "statement_markdown": "Vorbereitung",
+            },
+        ],
+    }
+
+    upload = UploadFile(
+        filename="tasks.json",
+        file=BytesIO(json.dumps(payload).encode("utf-8")),
+    )
+
+    response = asyncio.run(import_tasks_data(upload=upload, db=session))
+    assert response.status_code == 303
+
+    tasks = session.scalars(select(Task).order_by(Task.title)).unique().all()
+    assert len(tasks) == 2
+    main_task = next(task for task in tasks if task.title == "Analysis Aufgabe")
+    dependency_task = next(task for task in tasks if task.title == "Grundaufgabe")
+    assert dependency_task in main_task.dependencies
+
+    requirement = session.scalars(select(CategoryRequirement)).one()
+    assert requirement.required_count == 2
+
+    stored_image = session.scalars(select(TaskImage)).first()
+    assert stored_image is not None
+    stored_file = (Path("app/static") / stored_image.file_path)
+    assert stored_file.exists()
+    assert stored_file.read_bytes() == image_bytes
+
+    stored_file.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- add TaskImage and Category tables with an active exam flag and include task image URLs in exam payloads
- enable task image uploads, category dropdowns, and JSON import/export with base64 image handling across the UI
- provide a persistent live student view with markdown preview endpoints and refreshed teacher/student templates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3f75e2698832c957845eb71d859f2