### PR TITLE
Overhaul UI and exam configuration workflow

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from io import BytesIO
 import base64
 import json
-import mimetypes
 from pathlib import Path
 from typing import List, Optional
 from uuid import uuid4
@@ -22,13 +21,15 @@ from fastapi import (
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from PIL import Image, UnidentifiedImageError
 from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session, joinedload, selectinload
 
-from .db import get_db, init_db, session_scope
+from .db import get_db, init_db
 from .models import (
     Category,
-    CategoryRequirement,
+    ExamConfiguration,
+    ExamConfigurationRequirement,
     ExamSession,
     ExamTaskAssignment,
     StudentGroup,
@@ -38,7 +39,7 @@ from .models import (
 from .services.exam_service import (
     ExamGenerationError,
     build_exam_payload,
-    generate_exam_for_group,
+    generate_exam,
     regenerate_exam,
 )
 from .services.markdown_service import render_markdown
@@ -51,23 +52,6 @@ UPLOAD_DIR = STATIC_DIR / "uploads"
 app = FastAPI(title="Examination Tool", default_response_class=HTMLResponse)
 templates = Jinja2Templates(directory="app/templates")
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
-
-
-def _sync_category_nodes(db: Session) -> None:
-    existing = {
-        category.name: category
-        for category in db.scalars(
-            select(Category).where(Category.parent_id.is_(None))
-        )
-    }
-    requirements = db.scalars(select(CategoryRequirement)).all()
-    for requirement in requirements:
-        if requirement.category not in existing:
-            node = Category(name=requirement.category)
-            db.add(node)
-            existing[requirement.category] = node
-    db.flush()
-
 
 def _get_category_tree(db: Session) -> List[Category]:
     return (
@@ -145,42 +129,124 @@ def _delete_image_file(image: TaskImage) -> None:
         file_path.unlink()
     except FileNotFoundError:
         pass
+    if image.thumbnail_path:
+        try:
+            (STATIC_DIR / image.thumbnail_path).unlink()
+        except FileNotFoundError:
+            pass
 
 
-def _guess_file_suffix(original_filename: str, mime_type: str | None) -> str:
-    suffix = Path(original_filename).suffix
-    if suffix:
-        return suffix
-    if mime_type:
-        guessed = mimetypes.guess_extension(mime_type)
-        if guessed:
-            return guessed
-    return ""
+TARGET_IMAGE_SIZE = (1200, 900)
+THUMBNAIL_SIZE = (320, 240)
 
 
-async def _save_uploaded_images(task: Task, images: List[UploadFile]) -> None:
+def _sanitize_crop_data(raw: dict | None) -> dict | None:
+    if not raw:
+        return None
+    try:
+        x = float(raw.get("x", 0))
+        y = float(raw.get("y", 0))
+        width = float(raw.get("width", 0))
+        height = float(raw.get("height", 0))
+    except (TypeError, ValueError):
+        return None
+    if width <= 0 or height <= 0:
+        return None
+    return {"x": x, "y": y, "width": width, "height": height}
+
+
+def _ensure_ratio(image: Image.Image, crop_data: dict | None) -> Image.Image:
+    working = image
+    if crop_data:
+        left = max(0, int(round(crop_data["x"])))
+        upper = max(0, int(round(crop_data["y"])))
+        right = min(image.width, left + int(round(crop_data["width"])))
+        lower = min(image.height, upper + int(round(crop_data["height"])))
+        if right > left and lower > upper:
+            working = image.crop((left, upper, right, lower))
+    target_ratio = TARGET_IMAGE_SIZE[0] / TARGET_IMAGE_SIZE[1]
+    current_ratio = working.width / working.height
+    if abs(current_ratio - target_ratio) < 0.01:
+        return working
+    if current_ratio > target_ratio:
+        new_width = int(working.height * target_ratio)
+        offset = max(0, (working.width - new_width) // 2)
+        return working.crop((offset, 0, offset + new_width, working.height))
+    new_height = int(working.width / target_ratio)
+    offset = max(0, (working.height - new_height) // 2)
+    return working.crop((0, offset, working.width, offset + new_height))
+
+
+def _resize(image: Image.Image, size: tuple[int, int]) -> Image.Image:
+    return image.resize(size, Image.LANCZOS)
+
+
+def _prepare_image_bytes(content: bytes, crop_data: dict | None) -> tuple[bytes, bytes]:
+    try:
+        with Image.open(BytesIO(content)) as original:
+            original = original.convert("RGB")
+            framed = _ensure_ratio(original, crop_data)
+            resized = _resize(framed, TARGET_IMAGE_SIZE)
+            buffer = BytesIO()
+            resized.save(buffer, format="JPEG", quality=90)
+            main_bytes = buffer.getvalue()
+
+            thumb = _resize(resized, THUMBNAIL_SIZE)
+            thumb_buffer = BytesIO()
+            thumb.save(thumb_buffer, format="JPEG", quality=85)
+            return main_bytes, thumb_buffer.getvalue()
+    except UnidentifiedImageError:
+        # The imported payload may contain historic binary attachments that are not valid
+        # images. Preserve the original content without transformation so legacy exports
+        # can still be restored.
+        return content, content
+
+
+def _parse_crop_metadata(raw: str | None) -> dict[str, dict]:
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:  # pragma: no cover
+        raise HTTPException(status_code=400, detail="Ungültige Daten zum Bildzuschnitt.") from exc
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="Ungültige Daten zum Bildzuschnitt.")
+    result: dict[str, dict] = {}
+    for key, value in payload.items():
+        if isinstance(value, dict):
+            result[key] = value
+    return result
+
+async def _save_uploaded_images(
+    task: Task, images: List[UploadFile], crop_metadata: dict[str, dict] | None
+) -> None:
     if not images:
         return
 
     UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
     existing_count = len(task.images)
+    crop_metadata = crop_metadata or {}
     for index, upload in enumerate(images):
         if not upload.filename:
             continue
         if not upload.content_type or not upload.content_type.startswith("image/"):
             raise HTTPException(status_code=400, detail="Nur Bilddateien sind erlaubt.")
 
-        suffix = _guess_file_suffix(upload.filename, upload.content_type)
-        unique_name = f"{uuid4().hex}{suffix}"
-        destination = UPLOAD_DIR / unique_name
+        crop_data = _sanitize_crop_data(crop_metadata.get(upload.filename))
         content = await upload.read()
-        destination.write_bytes(content)
+        main_bytes, thumb_bytes = _prepare_image_bytes(content, crop_data)
+        base_name = uuid4().hex
+        image_name = f"{base_name}.jpg"
+        thumb_name = f"{base_name}_thumb.jpg"
+        (UPLOAD_DIR / image_name).write_bytes(main_bytes)
+        (UPLOAD_DIR / thumb_name).write_bytes(thumb_bytes)
 
         image = TaskImage(
             task=task,
-            file_path=f"uploads/{unique_name}",
+            file_path=f"uploads/{image_name}",
+            thumbnail_path=f"uploads/{thumb_name}",
             original_filename=upload.filename,
-            mime_type=upload.content_type or "application/octet-stream",
+            mime_type="image/jpeg",
             position=existing_count + index,
         )
         task.images.append(image)
@@ -202,15 +268,21 @@ def _encode_task_image(image: TaskImage) -> Optional[dict]:
     if not file_path.exists():
         return None
     data = base64.b64encode(file_path.read_bytes()).decode("utf-8")
+    thumbnail_data = None
+    if image.thumbnail_path:
+        thumbnail_file = STATIC_DIR / image.thumbnail_path
+        if thumbnail_file.exists():
+            thumbnail_data = base64.b64encode(thumbnail_file.read_bytes()).decode("utf-8")
     return {
         "original_filename": image.original_filename,
         "mime_type": image.mime_type,
         "data": data,
         "position": image.position,
+        "thumbnail": thumbnail_data,
     }
 
 
-def _store_imported_image(data: dict) -> tuple[str, str, str]:
+def _store_imported_image(data: dict) -> tuple[str, str, str, str]:
     encoded = data.get("data")
     if not encoded:
         raise HTTPException(
@@ -222,19 +294,20 @@ def _store_imported_image(data: dict) -> tuple[str, str, str]:
         raise HTTPException(status_code=400, detail="Ungültige Bilddaten im Import.") from exc
 
     original_filename = data.get("original_filename", "attachment")
-    mime_type = data.get("mime_type", "application/octet-stream")
-    suffix = _guess_file_suffix(original_filename, mime_type)
-    unique_name = f"{uuid4().hex}{suffix}"
+    crop_data = _sanitize_crop_data(data.get("crop"))
+    main_bytes, thumb_bytes = _prepare_image_bytes(content, crop_data)
+    base_name = uuid4().hex
+    unique_name = f"{base_name}.jpg"
+    thumb_name = f"{base_name}_thumb.jpg"
     UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
     destination = UPLOAD_DIR / unique_name
-    destination.write_bytes(content)
-    return unique_name, original_filename, mime_type
+    destination.write_bytes(main_bytes)
+    (UPLOAD_DIR / thumb_name).write_bytes(thumb_bytes)
+    return unique_name, thumb_name, original_filename, "image/jpeg"
 @app.on_event("startup")
 async def on_startup() -> None:
     init_db()
     UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
-    with session_scope() as db:
-        _sync_category_nodes(db)
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -242,8 +315,6 @@ def index(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
     groups = (
         db.scalars(select(StudentGroup).order_by(StudentGroup.label)).unique().all()
     )
-    category_requirements = db.scalars(select(CategoryRequirement).order_by(CategoryRequirement.category)).all()
-    requirements_map = {requirement.category: requirement for requirement in category_requirements}
     tasks_count = db.scalar(select(func.count()).select_from(Task)) or 0
     latest_exam = db.scalars(
         select(ExamSession)
@@ -252,9 +323,26 @@ def index(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
         .limit(1)
     ).unique().first()
     category_tree = _get_category_tree(db)
+    configurations = (
+        db.scalars(
+            select(ExamConfiguration)
+            .options(
+                selectinload(ExamConfiguration.requirements)
+                .selectinload(ExamConfigurationRequirement.category)
+            )
+            .options(
+                selectinload(ExamConfiguration.requirements)
+                .selectinload(ExamConfigurationRequirement.subcategory)
+            )
+            .order_by(ExamConfiguration.name)
+        )
+        .unique()
+        .all()
+    )
     active_exam = db.scalars(
         select(ExamSession)
         .options(joinedload(ExamSession.group))
+        .options(joinedload(ExamSession.configuration))
         .where(ExamSession.is_active.is_(True))
         .order_by(ExamSession.started_at.desc())
         .limit(1)
@@ -266,13 +354,13 @@ def index(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
         {
             "request": request,
             "groups": groups,
-            "category_requirements": category_requirements,
             "category_tree": category_tree,
-            "requirements_map": requirements_map,
+            "configurations": configurations,
             "tasks_count": tasks_count,
             "latest_exam": latest_exam,
             "active_exam": active_exam,
             "student_live_url": student_live_url,
+            "has_groups": bool(groups),
         },
     )
 
@@ -398,10 +486,12 @@ async def create_task(
     title: str = Form(...),
     category_id: int = Form(...),
     subcategory_id: Optional[str] = Form(None),
+    difficulty: int = Form(2),
     statement_markdown: str = Form(...),
     hints_markdown: Optional[str] = Form(None),
     solution_markdown: Optional[str] = Form(None),
     dependency_ids: Optional[str] = Form(None),
+    crop_metadata: str = Form("{}"),
     images: List[UploadFile] = File([]),
     db: Session = Depends(get_db),
 ) -> Response:
@@ -409,10 +499,13 @@ async def create_task(
     category_node, subcategory_node = _resolve_category_selection(
         db, category_id, subcategory_pk
     )
+    difficulty_value = max(1, min(3, int(difficulty)))
+    crop_data = _parse_crop_metadata(crop_metadata)
     task = Task(
         title=title.strip(),
         category=category_node.name,
         subcategory=subcategory_node.name if subcategory_node else None,
+        difficulty=difficulty_value,
         statement_markdown=statement_markdown,
         hints_markdown=hints_markdown,
         solution_markdown=solution_markdown,
@@ -424,7 +517,7 @@ async def create_task(
         dependencies = _parse_dependency_ids(dependency_ids, db, task.id)
         task.dependencies = dependencies
 
-    await _save_uploaded_images(task, images)
+    await _save_uploaded_images(task, images, crop_data)
     _normalize_image_positions(task)
     db.commit()
     return RedirectResponse(url="/tasks", status_code=303)
@@ -437,11 +530,13 @@ async def update_task(
     title: str = Form(...),
     category_id: int = Form(...),
     subcategory_id: Optional[str] = Form(None),
+    difficulty: int = Form(2),
     statement_markdown: str = Form(...),
     hints_markdown: Optional[str] = Form(None),
     solution_markdown: Optional[str] = Form(None),
     dependency_ids: Optional[str] = Form(None),
     remove_image_ids: List[str] = Form([]),
+    crop_metadata: str = Form("{}"),
     images: List[UploadFile] = File([]),
     db: Session = Depends(get_db),
 ) -> Response:
@@ -453,9 +548,12 @@ async def update_task(
     category_node, subcategory_node = _resolve_category_selection(
         db, category_id, subcategory_pk
     )
+    difficulty_value = max(1, min(3, int(difficulty)))
+    crop_data = _parse_crop_metadata(crop_metadata)
     task.title = title.strip()
     task.category = category_node.name
     task.subcategory = subcategory_node.name if subcategory_node else None
+    task.difficulty = difficulty_value
     task.statement_markdown = statement_markdown
     task.hints_markdown = hints_markdown
     task.solution_markdown = solution_markdown
@@ -475,7 +573,7 @@ async def update_task(
             _delete_image_file(image)
             db.delete(image)
 
-    await _save_uploaded_images(task, images)
+    await _save_uploaded_images(task, images, crop_data)
     _normalize_image_positions(task)
 
     db.commit()
@@ -485,14 +583,9 @@ async def update_task(
 @app.get("/tasks/export")
 def export_tasks_data(db: Session = Depends(get_db)) -> JSONResponse:
     categories = _get_category_tree(db)
-    requirements = {
-        requirement.category: requirement.required_count
-        for requirement in db.scalars(select(CategoryRequirement)).all()
-    }
     categories_payload = [
         {
             "name": category.name,
-            "required_count": requirements.get(category.name, 0),
             "subcategories": [
                 {"name": subcategory.name} for subcategory in category.children
             ],
@@ -516,6 +609,7 @@ def export_tasks_data(db: Session = Depends(get_db)) -> JSONResponse:
             "title": task.title,
             "category": task.category,
             "subcategory": task.subcategory,
+            "difficulty": task.difficulty,
             "statement_markdown": task.statement_markdown,
             "hints_markdown": task.hints_markdown,
             "solution_markdown": task.solution_markdown,
@@ -530,7 +624,47 @@ def export_tasks_data(db: Session = Depends(get_db)) -> JSONResponse:
             task_payload["images"] = images_payload
         tasks_payload.append(task_payload)
 
-    payload = {"categories": categories_payload, "tasks": tasks_payload}
+    configurations = (
+        db.scalars(
+            select(ExamConfiguration)
+            .options(
+                selectinload(ExamConfiguration.requirements)
+                .selectinload(ExamConfigurationRequirement.category)
+            )
+            .options(
+                selectinload(ExamConfiguration.requirements)
+                .selectinload(ExamConfigurationRequirement.subcategory)
+            )
+            .order_by(ExamConfiguration.name)
+        )
+        .unique()
+        .all()
+    )
+    configurations_payload = []
+    for configuration in configurations:
+        requirements_payload = []
+        for requirement in configuration.requirements:
+            requirements_payload.append(
+                {
+                    "category": requirement.category.name,
+                    "subcategory": requirement.subcategory.name if requirement.subcategory else None,
+                    "question_count": requirement.question_count,
+                    "position": requirement.position,
+                }
+            )
+        configurations_payload.append(
+            {
+                "name": configuration.name,
+                "target_difficulty": configuration.target_difficulty,
+                "requirements": requirements_payload,
+            }
+        )
+
+    payload = {
+        "categories": categories_payload,
+        "tasks": tasks_payload,
+        "configurations": configurations_payload,
+    }
     headers = {
         "Content-Disposition": "attachment; filename=examination_tasks_export.json"
     }
@@ -552,26 +686,17 @@ async def import_tasks_data(
 
     categories_data = payload.get("categories", []) or []
     tasks_data = payload.get("tasks", []) or []
+    configurations_data = payload.get("configurations", []) or []
 
     created_categories = 0
     created_subcategories = 0
     imported_images = 0
+    processed_configurations = 0
 
     for category_entry in categories_data:
         name = (category_entry.get("name") or "").strip()
         if not name:
             continue
-        required_count = int(category_entry.get("required_count", 0) or 0)
-        requirement = db.scalars(
-            select(CategoryRequirement).where(CategoryRequirement.category == name)
-        ).first()
-        if requirement:
-            requirement.required_count = required_count
-        else:
-            requirement = CategoryRequirement(category=name, required_count=required_count)
-            db.add(requirement)
-            created_categories += 1
-
         category_node = db.scalars(
             select(Category)
             .where(Category.name == name)
@@ -608,10 +733,16 @@ async def import_tasks_data(
         if not title:
             continue
         statement_markdown = task_entry.get("statement_markdown") or ""
+        try:
+            difficulty_value = int(task_entry.get("difficulty", 2) or 2)
+        except (TypeError, ValueError):
+            difficulty_value = 2
+        difficulty_value = max(1, min(3, difficulty_value))
         task = Task(
             title=title,
             category=(task_entry.get("category") or "").strip(),
             subcategory=(task_entry.get("subcategory") or None),
+            difficulty=difficulty_value,
             statement_markdown=statement_markdown,
             hints_markdown=task_entry.get("hints_markdown"),
             solution_markdown=task_entry.get("solution_markdown"),
@@ -625,14 +756,15 @@ async def import_tasks_data(
         images = task_entry.get("images", []) or []
         for position, image_entry in enumerate(images):
             try:
-                unique_name, original_filename, mime_type = _store_imported_image(
-                    image_entry
+                unique_name, thumb_name, original_filename, mime_type = (
+                    _store_imported_image(image_entry)
                 )
             except HTTPException:
                 continue
             image = TaskImage(
                 task=task,
                 file_path=f"uploads/{unique_name}",
+                thumbnail_path=f"uploads/{thumb_name}",
                 original_filename=original_filename,
                 mime_type=mime_type,
                 position=image_entry.get("position", position),
@@ -658,6 +790,62 @@ async def import_tasks_data(
                 dependencies.append(mapped)
         task.dependencies = dependencies
 
+    db.flush()
+
+    for config_entry in configurations_data:
+        name = (config_entry.get("name") or "").strip()
+        if not name:
+            continue
+        try:
+            target = float(config_entry.get("target_difficulty", 2.0) or 2.0)
+        except (TypeError, ValueError):
+            target = 2.0
+        configuration = db.scalars(
+            select(ExamConfiguration).where(ExamConfiguration.name == name)
+        ).first()
+        if not configuration:
+            configuration = ExamConfiguration(name=name, target_difficulty=target)
+            db.add(configuration)
+            db.flush()
+        else:
+            configuration.target_difficulty = target
+            configuration.requirements.clear()
+        processed_configurations += 1
+
+        requirements_data = config_entry.get("requirements", []) or []
+        for position, requirement_entry in enumerate(requirements_data):
+            category_name = (requirement_entry.get("category") or "").strip()
+            if not category_name:
+                continue
+            category = db.scalars(
+                select(Category)
+                .where(Category.parent_id.is_(None))
+                .where(Category.name == category_name)
+            ).first()
+            if not category:
+                continue
+            subcategory_name = (requirement_entry.get("subcategory") or "").strip()
+            subcategory = None
+            if subcategory_name:
+                subcategory = db.scalars(
+                    select(Category)
+                    .where(Category.parent_id == category.id)
+                    .where(Category.name == subcategory_name)
+                ).first()
+            try:
+                question_count = int(requirement_entry.get("question_count", 1) or 1)
+            except (TypeError, ValueError):
+                question_count = 1
+            question_count = max(1, question_count)
+            configuration.requirements.append(
+                ExamConfigurationRequirement(
+                    category_id=category.id,
+                    subcategory_id=subcategory.id if subcategory else None,
+                    question_count=question_count,
+                    position=position,
+                )
+            )
+
     db.commit()
 
     params = (
@@ -666,6 +854,7 @@ async def import_tasks_data(
         f"&categories={created_categories}"
         f"&subcategories={created_subcategories}"
         f"&images={imported_images}"
+        f"&configurations={processed_configurations}"
     )
     return RedirectResponse(url=f"/tasks{params}", status_code=303)
 
@@ -682,58 +871,217 @@ def delete_task(task_id: int, db: Session = Depends(get_db)) -> Response:
     return RedirectResponse(url="/tasks", status_code=303)
 
 
+@app.post("/tasks/{task_id}/copy")
+def copy_task(task_id: int, db: Session = Depends(get_db)) -> Response:
+    task = db.scalars(
+        select(Task)
+        .options(joinedload(Task.dependencies), joinedload(Task.images))
+        .where(Task.id == task_id)
+    ).unique().first()
+    if not task:
+        raise HTTPException(status_code=404, detail="Aufgabe nicht gefunden")
+
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    new_task = Task(
+        title=f"Kopie von {task.title}",
+        category=task.category,
+        subcategory=task.subcategory,
+        difficulty=task.difficulty,
+        statement_markdown=task.statement_markdown,
+        hints_markdown=task.hints_markdown,
+        solution_markdown=task.solution_markdown,
+    )
+    db.add(new_task)
+    db.flush()
+
+    new_task.dependencies = list(task.dependencies)
+
+    for image in task.images:
+        source = STATIC_DIR / image.file_path
+        if not source.exists():
+            continue
+        base_name = uuid4().hex
+        suffix = Path(source.name).suffix or ".jpg"
+        new_main_name = f"{base_name}{suffix}"
+        (UPLOAD_DIR / new_main_name).write_bytes(source.read_bytes())
+
+        new_thumb_path: Optional[str] = None
+        if image.thumbnail_path:
+            thumb_source = STATIC_DIR / image.thumbnail_path
+            if thumb_source.exists():
+                thumb_suffix = Path(thumb_source.name).suffix or ".jpg"
+                new_thumb_name = f"{base_name}_thumb{thumb_suffix}"
+                (UPLOAD_DIR / new_thumb_name).write_bytes(thumb_source.read_bytes())
+                new_thumb_path = f"uploads/{new_thumb_name}"
+
+        copied_image = TaskImage(
+            task=new_task,
+            file_path=f"uploads/{new_main_name}",
+            thumbnail_path=new_thumb_path,
+            original_filename=image.original_filename,
+            mime_type=image.mime_type,
+            position=image.position,
+        )
+        db.add(copied_image)
+
+    _normalize_image_positions(new_task)
+    db.commit()
+    return RedirectResponse(url=f"/tasks/{new_task.id}/edit", status_code=303)
+
+
 @app.get("/categories", response_class=HTMLResponse)
 def list_categories(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
-    requirements = {
-        requirement.category: requirement
-        for requirement in db.scalars(
-            select(CategoryRequirement).order_by(CategoryRequirement.category)
-        ).all()
-    }
     categories = _get_category_tree(db)
     return templates.TemplateResponse(
         "categories.html",
         {
             "request": request,
             "categories": categories,
-            "requirements": requirements,
         },
     )
 
 
+@app.get("/exam-configurations/new", response_class=HTMLResponse)
+def new_exam_configuration(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
+    categories = _get_category_tree(db)
+    category_options_json = json.dumps(
+        _serialize_category_options(categories), ensure_ascii=False
+    )
+    return templates.TemplateResponse(
+        "exam_configuration_form.html",
+        {
+            "request": request,
+            "categories": categories,
+            "category_options_json": category_options_json,
+        },
+    )
+
+
+@app.post("/exam-configurations")
+async def create_exam_configuration(
+    name: str = Form(...),
+    target_difficulty: float = Form(...),
+    requirements_json: str = Form(...),
+    db: Session = Depends(get_db),
+) -> Response:
+    configuration_name = name.strip()
+    if not configuration_name:
+        raise HTTPException(status_code=400, detail="Die Konfiguration benötigt einen Namen.")
+
+    existing = db.scalars(
+        select(ExamConfiguration).where(ExamConfiguration.name == configuration_name)
+    ).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Eine Konfiguration mit diesem Namen existiert bereits.")
+
+    try:
+        requirements_payload = json.loads(requirements_json)
+    except json.JSONDecodeError as exc:  # pragma: no cover
+        raise HTTPException(status_code=400, detail="Ungültige Kategorienauswahl.") from exc
+    if not isinstance(requirements_payload, list) or not requirements_payload:
+        raise HTTPException(status_code=400, detail="Es muss mindestens eine Kategorie ausgewählt werden.")
+
+    difficulty_value = max(1.0, min(3.0, float(target_difficulty)))
+
+    configuration = ExamConfiguration(
+        name=configuration_name,
+        target_difficulty=difficulty_value,
+    )
+    db.add(configuration)
+    db.flush()
+
+    for position, requirement in enumerate(requirements_payload):
+        category_id = requirement.get("category_id")
+        if category_id is None:
+            continue
+        category = db.get(Category, int(category_id))
+        if not category or category.parent_id is not None:
+            raise HTTPException(status_code=400, detail="Ungültige Kategorie ausgewählt.")
+
+        subcategory_id = requirement.get("subcategory_id")
+        subcategory = None
+        if subcategory_id:
+            subcategory = db.get(Category, int(subcategory_id))
+            if not subcategory or subcategory.parent_id != category.id:
+                raise HTTPException(status_code=400, detail="Ungültige Unterkategorie ausgewählt.")
+
+        try:
+            question_count = int(requirement.get("question_count", 1) or 1)
+        except (TypeError, ValueError):
+            question_count = 1
+        question_count = max(1, question_count)
+
+        configuration.requirements.append(
+            ExamConfigurationRequirement(
+                category_id=category.id,
+                subcategory_id=subcategory.id if subcategory else None,
+                question_count=question_count,
+                position=position,
+            )
+        )
+
+    db.commit()
+    return RedirectResponse(url="/", status_code=303)
+
+
+@app.post("/exam-configurations/{configuration_id}/delete")
+def delete_exam_configuration(
+    configuration_id: int, db: Session = Depends(get_db)
+) -> Response:
+    configuration = db.get(ExamConfiguration, configuration_id)
+    if not configuration:
+        raise HTTPException(status_code=404, detail="Konfiguration nicht gefunden.")
+    active_sessions = db.scalar(
+        select(func.count())
+        .select_from(ExamSession)
+        .where(ExamSession.configuration_id == configuration_id)
+    )
+    if active_sessions:
+        raise HTTPException(
+            status_code=400,
+            detail="Die Konfiguration wird noch von Prüfungen verwendet und kann nicht gelöscht werden.",
+        )
+    db.delete(configuration)
+    db.commit()
+    return RedirectResponse(url="/", status_code=303)
+
+
 @app.post("/categories")
 async def save_category(
-    category: str = Form(...),
-    required_count: int = Form(...),
+    name: str = Form(...),
     category_id: Optional[int] = Form(None),
     db: Session = Depends(get_db),
 ) -> Response:
-    category_name = category.strip()
+    category_name = name.strip()
+    if not category_name:
+        raise HTTPException(status_code=400, detail="Die Kategorie benötigt einen Namen.")
+
     if category_id:
-        requirement = db.get(CategoryRequirement, category_id)
-        if not requirement:
+        category = db.get(Category, category_id)
+        if not category or category.parent_id is not None:
             raise HTTPException(status_code=404, detail="Kategorie nicht gefunden")
-        requirement.category = category_name
-        requirement.required_count = required_count
-        category_node = db.scalars(
-            select(Category)
-            .where(Category.name == category_name)
-            .where(Category.parent_id.is_(None))
-        ).first()
-        if not category_node:
-            db.add(Category(name=category_name))
-    else:
-        requirement = CategoryRequirement(
-            category=category_name, required_count=required_count
-        )
-        db.add(requirement)
         existing = db.scalars(
             select(Category)
-            .where(Category.name == category_name)
             .where(Category.parent_id.is_(None))
+            .where(Category.name == category_name)
+            .where(Category.id != category.id)
         ).first()
-        if not existing:
-            db.add(Category(name=category_name))
+        if existing:
+            raise HTTPException(status_code=400, detail="Kategorie existiert bereits.")
+        if category.name != category_name:
+            old_name = category.name
+            for task in db.scalars(select(Task).where(Task.category == old_name)).all():
+                task.category = category_name
+            category.name = category_name
+    else:
+        existing = db.scalars(
+            select(Category)
+            .where(Category.parent_id.is_(None))
+            .where(Category.name == category_name)
+        ).first()
+        if existing:
+            raise HTTPException(status_code=400, detail="Kategorie existiert bereits.")
+        db.add(Category(name=category_name))
 
     db.commit()
     return RedirectResponse(url="/categories", status_code=303)
@@ -741,27 +1089,18 @@ async def save_category(
 
 @app.post("/categories/{category_id}/delete")
 def delete_category(category_id: int, db: Session = Depends(get_db)) -> Response:
-    requirement = db.get(CategoryRequirement, category_id)
-    if not requirement:
+    category = db.get(Category, category_id)
+    if not category or category.parent_id is not None:
         raise HTTPException(status_code=404, detail="Kategorie nicht gefunden")
     tasks_in_category = db.scalar(
-        select(func.count())
-        .select_from(Task)
-        .where(Task.category == requirement.category)
+        select(func.count()).select_from(Task).where(Task.category == category.name)
     )
     if tasks_in_category:
         raise HTTPException(
             status_code=400,
             detail="Kategorie kann nicht gelöscht werden, solange ihr Aufgaben zugeordnet sind.",
         )
-    category_node = db.scalars(
-        select(Category)
-        .where(Category.name == requirement.category)
-        .where(Category.parent_id.is_(None))
-    ).first()
-    if category_node:
-        db.delete(category_node)
-    db.delete(requirement)
+    db.delete(category)
     db.commit()
     return RedirectResponse(url="/categories", status_code=303)
 
@@ -788,6 +1127,44 @@ async def add_subcategory(
 
     subcategory = Category(name=subcategory_name, parent=parent)
     db.add(subcategory)
+    db.commit()
+    return RedirectResponse(url="/categories", status_code=303)
+
+
+@app.post("/categories/{category_id}/subcategories/{subcategory_id}/rename")
+def rename_subcategory(
+    category_id: int,
+    subcategory_id: int,
+    name: str = Form(...),
+    db: Session = Depends(get_db),
+) -> Response:
+    parent = db.get(Category, category_id)
+    if not parent or parent.parent_id is not None:
+        raise HTTPException(status_code=404, detail="Kategorie nicht gefunden")
+    subcategory = db.get(Category, subcategory_id)
+    if not subcategory or subcategory.parent_id != parent.id:
+        raise HTTPException(status_code=404, detail="Unterkategorie nicht gefunden")
+    new_name = name.strip()
+    if not new_name:
+        raise HTTPException(status_code=400, detail="Unterkategorie benötigt einen Namen.")
+    existing = db.scalars(
+        select(Category)
+        .where(Category.parent_id == parent.id)
+        .where(Category.name == new_name)
+        .where(Category.id != subcategory.id)
+    ).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Unterkategorie existiert bereits.")
+    if subcategory.name != new_name:
+        old_name = subcategory.name
+        for task in db.scalars(
+            select(Task)
+            .where(Task.category == parent.name)
+            .where(Task.subcategory == old_name)
+        ).all():
+            task.subcategory = new_name
+        subcategory.name = new_name
+
     db.commit()
     return RedirectResponse(url="/categories", status_code=303)
 
@@ -820,9 +1197,25 @@ def delete_subcategory(
 
 
 @app.post("/exams")
-def create_exam(group_id: int = Form(...), db: Session = Depends(get_db)) -> Response:
+def create_exam(
+    configuration_id: int = Form(...),
+    group_id: Optional[str] = Form(None),
+    demo_label: str = Form("Testmodus"),
+    db: Session = Depends(get_db),
+) -> Response:
     try:
-        exam = generate_exam_for_group(db, group_id)
+        group_pk = int(group_id) if group_id else None
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="Ungültige Gruppe ausgewählt.")
+
+    demo_name = demo_label.strip() or "Testmodus"
+    try:
+        exam = generate_exam(
+            db,
+            configuration_id=configuration_id,
+            group_id=group_pk,
+            demo_label=demo_name if group_pk is None else None,
+        )
         _mark_exam_as_active(db, exam)
         db.commit()
     except ExamGenerationError as exc:

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,392 +1,550 @@
 :root {
   color-scheme: light;
-  font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
-  --primary: #2d5be3;
-  --background: #f7f8fb;
-  --text: #222;
+  font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --surface: #ffffff;
+  --surface-alt: #f5f6fb;
+  --text: #111827;
   --muted: #6b7280;
   --border: #e5e7eb;
+  --success: #16a34a;
+  --danger: #dc2626;
+  --shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  background: var(--background);
+  background: var(--surface-alt);
   color: var(--text);
 }
 
-.container {
-  margin: 0 auto;
-  padding: 1.5rem;
-  max-width: 1100px;
+a {
+  color: inherit;
 }
 
-.topbar {
-  background: white;
+.app-bar {
+  background: var(--surface);
   border-bottom: 1px solid var(--border);
-  box-shadow: 0 1px 4px rgba(15, 23, 42, 0.08);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
 }
 
-.brand a {
-  text-decoration: none;
+.app-bar__content {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  gap: 1rem;
+}
+
+.app-bar__brand {
+  font-weight: 700;
+  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   color: var(--primary);
+  text-decoration: none;
 }
 
-.topbar nav {
+.app-bar__nav {
   display: flex;
   gap: 1rem;
-  align-items: center;
   flex-wrap: wrap;
 }
 
-.topbar nav a {
-  color: var(--muted);
+.app-bar__nav a {
   text-decoration: none;
+  color: var(--muted);
   font-weight: 600;
+  padding: 0.35rem 0.6rem;
+  border-radius: 9999px;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
-.topbar nav a:hover {
+.app-bar__nav a:hover,
+.app-bar__nav a:focus {
+  background: rgba(37, 99, 235, 0.12);
   color: var(--primary);
 }
 
-main.container {
-  padding-top: 2rem;
+main {
+  padding: 2rem 1.5rem 3rem;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.page-title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+}
+
+.cards-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 2rem;
 }
 
 .card {
-  background: white;
-  border-radius: 0.75rem;
-  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: 1rem;
   padding: 1.5rem;
-  margin-bottom: 1.5rem;
-  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(148, 163, 184, 0.15);
 }
 
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 1.5rem;
-  margin-top: 1rem;
+.card h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.6rem;
 }
 
-.stats-grid strong {
-  display: block;
-  font-size: 2rem;
+.stat-value {
+  font-size: 2.5rem;
+  font-weight: 700;
   color: var(--primary);
 }
 
-.table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.table thead {
-  background: #eef2ff;
-}
-
-.table th,
-.table td {
-  border: 1px solid var(--border);
-  padding: 0.75rem;
-  text-align: left;
-}
-
-.table tbody tr:nth-child(odd) {
-  background: #fafbff;
-}
-
-button,
-.button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.5rem 1rem;
-  background: var(--primary);
-  color: white;
-  border: none;
-  border-radius: 0.5rem;
-  cursor: pointer;
-  font-size: 1rem;
-  text-decoration: none;
-}
-
-button.secondary,
-.button.secondary {
-  background: #64748b;
-}
-
-button.danger,
-.button.danger {
-  background: #dc2626;
-}
-
-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-form .form-row {
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 1rem;
-}
-
-form label {
-  font-weight: 600;
-  margin-bottom: 0.25rem;
-}
-
-form input,
-form textarea,
-form select {
-  padding: 0.6rem 0.7rem;
-  border: 1px solid var(--border);
-  border-radius: 0.5rem;
-  font-size: 1rem;
-  font-family: inherit;
-}
-
-textarea {
-  min-height: 160px;
-}
-
-.task-card {
-  border-left: 4px solid var(--primary);
-  margin-bottom: 1rem;
-  padding-left: 1rem;
-}
-
-.task-metadata {
+.text-muted {
   color: var(--muted);
-  font-size: 0.95rem;
-  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
 }
 
-.alert {
-  padding: 0.75rem 1rem;
-  border-radius: 0.5rem;
-  margin-bottom: 1rem;
-}
-
-.alert.success {
-  background: #dcfce7;
-  color: #166534;
-}
-
-.alert.error {
-  background: #fee2e2;
-  color: #b91c1c;
-}
-
-.exam-layout {
+.task-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 1.5rem;
 }
 
-.exam-task {
-  border: 1px solid var(--border);
-  border-radius: 0.75rem;
-  padding: 1.25rem;
-  background: white;
-}
-
-.exam-task h2 {
-  margin-top: 0;
-  margin-bottom: 0.5rem;
-}
-
-.exam-task .section-title {
-  color: var(--muted);
-  text-transform: uppercase;
-  font-size: 0.8rem;
-  letter-spacing: 0.08em;
-  margin-top: 1rem;
-}
-
-@media (max-width: 640px) {
-  .container {
-    padding: 1rem;
-  }
-
-  .topbar nav {
-    gap: 0.5rem;
-  }
-}
-
-.markdown-editor-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1rem;
-}
-
-.markdown-editor textarea {
-  min-height: 220px;
-}
-
-.markdown-preview {
-  border: 1px solid var(--border);
-  border-radius: 0.5rem;
-  background: #f9fafb;
-  padding: 0.75rem;
-  min-height: 220px;
-  overflow-y: auto;
-}
-
-.task-toolbar {
+.task-card {
+  background: var(--surface);
+  border-radius: 1rem;
+  overflow: hidden;
   display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  flex-direction: column;
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(148, 163, 184, 0.15);
 }
 
-.task-toolbar-actions {
-  display: flex;
-  gap: 0.75rem;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-#task-import-form {
+.task-card__image {
   position: relative;
+  padding-top: 56.25%;
+  background: rgba(37, 99, 235, 0.05);
+  overflow: hidden;
 }
 
-#task-import-form input[type='file'] {
-  display: none;
+.task-card__image img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
-.task-images {
+.task-card__placeholder {
+  position: absolute;
+  inset: 0;
   display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin-top: 1rem;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: var(--muted);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(99, 102, 241, 0.12));
 }
 
-.task-images figure {
+.task-card__body {
+  padding: 1.25rem 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.task-card__title {
+  font-size: 1.15rem;
+  font-weight: 600;
   margin: 0;
 }
 
-.task-images img {
-  max-width: 220px;
-  border-radius: 0.5rem;
-  border: 1px solid var(--border);
-  display: block;
+.task-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  color: var(--muted);
+  font-size: 0.9rem;
 }
 
-.task-images figcaption {
-  margin-top: 0.35rem;
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+  padding: 0.25rem 0.6rem;
+  border-radius: 9999px;
   font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.chip--level-1 {
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+}
+
+.chip--level-2 {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+}
+
+.chip--level-3 {
+  background: rgba(220, 38, 38, 0.12);
+  color: var(--danger);
+}
+
+.button,
+button {
+  appearance: none;
+  border: none;
+  border-radius: 9999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  background: var(--primary);
+  color: white;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button:hover,
+button:hover,
+.button:focus,
+button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.2);
+}
+
+.button.secondary {
+  background: #475569;
+}
+
+.button.ghost {
+  background: transparent;
   color: var(--muted);
+  border: 1px solid var(--border);
+  box-shadow: none;
+}
+
+.button.danger {
+  background: var(--danger);
+}
+
+.button.small {
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+}
+
+.task-card__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.section {
+  margin-bottom: 3rem;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.25rem;
+  gap: 1rem;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.form-card {
+  background: var(--surface);
+  border-radius: 1rem;
+  box-shadow: var(--shadow);
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.form-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.form-field label {
+  font-weight: 600;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.form-field input,
+.form-field textarea,
+.form-field select {
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.65rem 0.8rem;
+  font-size: 1rem;
+  font-family: inherit;
+  background: var(--surface-alt);
+}
+
+textarea {
+  min-height: 200px;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.alert {
+  padding: 0.8rem 1rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+}
+
+.alert.success {
+  background: rgba(34, 197, 94, 0.12);
+  color: var(--success);
+}
+
+.alert.error {
+  background: rgba(248, 113, 113, 0.15);
+  color: var(--danger);
+}
+
+.category-tree {
+  background: var(--surface);
+  border-radius: 1rem;
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  padding: 1.5rem;
+}
+
+.category-tree ul {
+  list-style: none;
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.category-tree li {
+  margin-bottom: 0.5rem;
+  position: relative;
+  padding-left: 0.75rem;
+}
+
+.category-tree li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.6rem;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--primary);
+}
+
+.category-tree__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.35rem;
+}
+
+.config-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.config-card__requirements {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.config-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.inline-form {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.inline-form select,
+.inline-form input[type='number'] {
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  padding: 0.5rem 0.7rem;
+  background: var(--surface-alt);
+}
+
+.config-meta {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.markdown-preview {
+  border-radius: 0.75rem;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  padding: 0.75rem;
+  min-height: 200px;
 }
 
 .image-gallery {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
-}
-
-.image-gallery-item {
-  background: #f9fafb;
-  border: 1px solid var(--border);
-  border-radius: 0.75rem;
-  padding: 0.75rem;
-  text-align: center;
-  max-width: 220px;
-}
-
-.image-gallery-item img {
-  max-width: 100%;
-  border-radius: 0.5rem;
-  margin-bottom: 0.5rem;
-}
-
-.remove-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.35rem;
-  font-size: 0.9rem;
-}
-
-.share-link {
-  font-family: 'Fira Code', 'Courier New', monospace;
-  background: #eef2ff;
-  padding: 0.35rem 0.6rem;
-  border-radius: 0.5rem;
-  display: inline-block;
-  word-break: break-all;
-}
-
-.category-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1rem;
-}
-
-.category-card {
-  background: #f9fafb;
-  border: 1px solid var(--border);
-  border-radius: 0.75rem;
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.category-card header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 0.75rem;
-}
-
-.category-card header form {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  align-items: flex-end;
-}
-
-.category-card header form input[type='number'] {
-  width: 5rem;
-}
-
-.subcategory-list ul {
-  list-style: disc;
-  padding-left: 1.25rem;
-}
-
-.subcategory-list li {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 0.35rem;
-}
-
-.add-subcategory-form {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
   margin-top: 0.75rem;
 }
 
-.delete-category-form {
-  margin-top: auto;
+.image-gallery figure {
+  margin: 0;
+  background: var(--surface-alt);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  max-width: 220px;
 }
 
-.category-summary {
-  list-style: none;
-  padding-left: 0;
+.image-gallery img {
+  width: 100%;
+  border-radius: 0.5rem;
+  object-fit: cover;
 }
 
-.category-summary > li {
-  margin-bottom: 0.5rem;
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 600;
 }
 
-.category-summary ul {
-  list-style: disc;
-  margin-left: 1.25rem;
-  margin-top: 0.25rem;
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(2px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal.is-open {
+  display: flex;
+}
+
+.modal__content {
+  background: var(--surface);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  max-width: 640px;
+  width: 100%;
+  box-shadow: var(--shadow);
+}
+
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.crop-container {
+  max-height: 420px;
+  overflow: hidden;
+  border-radius: 0.75rem;
+}
+
+.task-media-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.task-media-preview canvas,
+.task-media-preview img {
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  max-width: 200px;
+  object-fit: cover;
+}
+
+.accent-link {
+  color: var(--primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.accent-link:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+  .app-bar__content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .form-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,12 +4,23 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}Examination Tool{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+    />
     <link rel="stylesheet" href="{{ url_for('static', path='styles.css') }}" />
     <script>
       window.MathJax = {
         tex: {
-          inlineMath: [['$', '$'], ['\\(', '\\)']],
-          displayMath: [['$$', '$$'], ['\\[', '\\]']]
+          inlineMath: [
+            ['$', '$'],
+            ['\\(', '\\)']
+          ],
+          displayMath: [
+            ['$$', '$$'],
+            ['\\[', '\\]']
+          ]
         },
         options: {
           skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
@@ -20,19 +31,25 @@
     {% block head_extra %}{% endblock %}
   </head>
   <body>
-    <header class="topbar">
-      <div class="container">
-        <h1 class="brand"><a href="/">Examination Tool</a></h1>
-        <nav>
+    <header class="app-bar">
+      <div class="app-bar__content">
+        <a class="app-bar__brand" href="/">
+          <span aria-hidden="true">📝</span>
+          Examination Tool
+        </a>
+        <nav class="app-bar__nav">
           <a href="/">Übersicht</a>
           <a href="/students/import">Studierende importieren</a>
           <a href="/tasks">Aufgaben</a>
           <a href="/categories">Kategorien</a>
+          <a href="/exam-configurations/new">Neue Prüfung</a>
         </nav>
       </div>
     </header>
-    <main class="container">
-      {% block content %}{% endblock %}
+    <main>
+      <div class="container">
+        {% block content %}{% endblock %}
+      </div>
     </main>
     {% block scripts %}{% endblock %}
   </body>

--- a/app/templates/categories.html
+++ b/app/templates/categories.html
@@ -3,88 +3,65 @@
 {% block title %}Kategorien · Examination Tool{% endblock %}
 
 {% block content %}
-  <section class="card">
-    <h2>Kategorien verwalten</h2>
-    <p>Lege fest, wie viele Aufgaben pro Kategorie zufällig ausgewählt werden, und verwalte passende Unterkategorien.</p>
-    <form method="post" action="/categories" style="margin-bottom:1.5rem;">
-      <h3>Neue Kategorie hinzufügen</h3>
-      <div class="form-row">
-        <label for="category">Kategorie</label>
-        <input id="category" type="text" name="category" required />
-      </div>
-      <div class="form-row">
-        <label for="required_count">Anzahl Aufgaben pro Prüfung</label>
-        <input id="required_count" type="number" min="1" name="required_count" value="1" required />
-      </div>
-      <button type="submit">Kategorie anlegen</button>
-    </form>
+  <h1 class="page-title">Kategorien verwalten</h1>
 
-    {% if not categories %}
-      <p>Noch keine Kategorien angelegt.</p>
-    {% else %}
-      <div class="category-grid">
-        {% for category in categories %}
-          {% set requirement = requirements.get(category.name) %}
-          <article class="category-card">
-            <header>
-              <h3>{{ category.name }}</h3>
-              {% if requirement %}
-                <form method="post" action="/categories">
-                  <input type="hidden" name="category_id" value="{{ requirement.id }}" />
-                  <input type="hidden" name="category" value="{{ requirement.category }}" />
-                  <label>
-                    Aufgaben pro Prüfung
-                    <input type="number" name="required_count" value="{{ requirement.required_count }}" min="1" required />
-                  </label>
-                  <button type="submit" class="secondary">Speichern</button>
-                </form>
-              {% endif %}
-            </header>
-            <div class="subcategory-list">
-              <h4>Unterkategorien</h4>
-              {% if not category.children %}
-                <p class="task-metadata">Noch keine Unterkategorien angelegt.</p>
-              {% else %}
-                <ul>
-                  {% for subcategory in category.children %}
-                    <li>
-                      {{ subcategory.name }}
-                      <form
-                        method="post"
-                        action="/categories/{{ category.id }}/subcategories/{{ subcategory.id }}/delete"
-                        onsubmit="return confirm('Unterkategorie wirklich löschen?');"
-                      >
-                        <button type="submit" class="danger">Löschen</button>
-                      </form>
-                    </li>
-                  {% endfor %}
-                </ul>
-              {% endif %}
-              <form method="post" action="/categories/{{ category.id }}/subcategories" class="add-subcategory-form">
-                <label for="new-subcategory-{{ category.id }}">Neue Unterkategorie</label>
-                <input
-                  id="new-subcategory-{{ category.id }}"
-                  type="text"
-                  name="name"
-                  placeholder="Bezeichnung"
-                  required
-                />
-                <button type="submit" class="secondary">Hinzufügen</button>
-              </form>
-            </div>
-            {% if requirement %}
-              <form
-                method="post"
-                action="/categories/{{ requirement.id }}/delete"
-                onsubmit="return confirm('Kategorie wirklich löschen? Alle Unterkategorien werden entfernt.');"
-                class="delete-category-form"
-              >
-                <button type="submit" class="danger">Kategorie löschen</button>
-              </form>
-            {% endif %}
-          </article>
-        {% endfor %}
+  <div class="form-card" style="margin-bottom:2rem;">
+    <form method="post" action="/categories">
+      <div class="form-field">
+        <label for="new-category-name">Neue Hauptkategorie</label>
+        <input id="new-category-name" type="text" name="name" placeholder="z. B. Analysis" required />
       </div>
-    {% endif %}
-  </section>
+      <div class="form-actions">
+        <button class="button" type="submit">Kategorie anlegen</button>
+      </div>
+    </form>
+  </div>
+
+  {% if not categories %}
+    <div class="card">
+      <p>Noch keine Kategorien vorhanden. Lege eine erste Hauptkategorie an, um Aufgaben zu strukturieren.</p>
+    </div>
+  {% else %}
+    <div class="form-grid">
+      {% for category in categories %}
+        <article class="card">
+          <form class="inline-form" method="post" action="/categories">
+            <input type="hidden" name="category_id" value="{{ category.id }}" />
+            <label for="rename-{{ category.id }}">Kategorie</label>
+            <input id="rename-{{ category.id }}" name="name" type="text" value="{{ category.name }}" required />
+            <button class="button secondary small" type="submit">Umbenennen</button>
+          </form>
+
+          <div class="category-tree__actions">
+            <form class="inline-form" method="post" action="/categories/{{ category.id }}/subcategories">
+              <label for="new-sub-{{ category.id }}">Unterkategorie</label>
+              <input id="new-sub-{{ category.id }}" name="name" type="text" placeholder="Neue Unterkategorie" required />
+              <button class="button secondary small" type="submit">Hinzufügen</button>
+            </form>
+            <form method="post" action="/categories/{{ category.id }}/delete" onsubmit="return confirm('Kategorie wirklich löschen? Alle Unterkategorien werden ebenfalls entfernt.');">
+              <button class="button danger small" type="submit">Kategorie löschen</button>
+            </form>
+          </div>
+
+          {% if category.children %}
+            <ul class="category-tree" style="margin-top:1rem; border: none; box-shadow:none; padding:0;">
+              {% for subcategory in category.children %}
+                <li>
+                  <form class="inline-form" method="post" action="/categories/{{ category.id }}/subcategories/{{ subcategory.id }}/rename">
+                    <input name="name" type="text" value="{{ subcategory.name }}" required />
+                    <button class="button secondary small" type="submit">Umbenennen</button>
+                  </form>
+                  <form method="post" action="/categories/{{ category.id }}/subcategories/{{ subcategory.id }}/delete" onsubmit="return confirm('Unterkategorie wirklich löschen?');">
+                    <button class="button ghost small" type="submit">Entfernen</button>
+                  </form>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="text-muted" style="margin-top:1rem;">Noch keine Unterkategorien angelegt.</p>
+          {% endif %}
+        </article>
+      {% endfor %}
+    </div>
+  {% endif %}
 {% endblock %}

--- a/app/templates/exam_configuration_form.html
+++ b/app/templates/exam_configuration_form.html
@@ -1,0 +1,182 @@
+{% extends "base.html" %}
+
+{% block title %}Neue Prüfungskonfiguration · Examination Tool{% endblock %}
+
+{% block content %}
+  <h1 class="page-title">Neue Prüfungskonfiguration</h1>
+
+  <div class="form-card">
+    <form id="configuration-form" method="post" action="/exam-configurations">
+      <input type="hidden" name="requirements_json" id="requirements-json" />
+      <div class="form-grid">
+        <div class="form-field">
+          <label for="configuration-name">Name der Konfiguration</label>
+          <input id="configuration-name" name="name" type="text" placeholder="z. B. Abschlussklausur" required />
+        </div>
+        <div class="form-field">
+          <label for="target-difficulty">Durchschnittliches Schwierigkeitsniveau</label>
+          <input id="target-difficulty" name="target_difficulty" type="range" min="1" max="3" step="0.5" value="2" />
+          <div class="badge" id="target-difficulty-display">Stufe 2.0</div>
+        </div>
+      </div>
+
+      <div class="form-field">
+        <label>Kategorien &amp; Anzahl Aufgaben</label>
+        <p class="text-muted">Lege fest, aus welchen Kategorien wie viele Aufgaben automatisch gezogen werden sollen. Die Reihenfolge bestimmt zugleich die Priorität bei der Auswahl.</p>
+        <div id="requirements-list" class="form-grid"></div>
+        <button type="button" class="button secondary small" id="add-requirement">Kategorie hinzufügen</button>
+      </div>
+
+      <div class="form-actions">
+        <a class="button ghost" href="/">Abbrechen</a>
+        <button type="submit" class="button">Konfiguration speichern</button>
+      </div>
+    </form>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    const CATEGORY_OPTIONS = {{ category_options_json|safe }};
+
+    (function() {
+      const listEl = document.getElementById('requirements-list');
+      const addBtn = document.getElementById('add-requirement');
+      const requirementsInput = document.getElementById('requirements-json');
+      const difficultyInput = document.getElementById('target-difficulty');
+      const difficultyDisplay = document.getElementById('target-difficulty-display');
+
+      const updateDifficultyDisplay = () => {
+        difficultyDisplay.textContent = `Stufe ${Number(difficultyInput.value).toFixed(1)}`;
+      };
+      difficultyInput.addEventListener('input', updateDifficultyDisplay);
+      updateDifficultyDisplay();
+
+      function buildCategorySelect(selectedId) {
+        const select = document.createElement('select');
+        select.required = true;
+        select.dataset.role = 'category';
+        select.innerHTML = '<option value="" disabled selected>Kategorie wählen</option>';
+        CATEGORY_OPTIONS.forEach(option => {
+          const opt = document.createElement('option');
+          opt.value = option.id;
+          opt.textContent = option.name;
+          if (String(option.id) === String(selectedId)) {
+            opt.selected = true;
+          }
+          select.appendChild(opt);
+        });
+        return select;
+      }
+
+      function buildSubcategorySelect(categoryId, selectedId) {
+        const select = document.createElement('select');
+        select.dataset.role = 'subcategory';
+        select.innerHTML = '<option value="">Alle Unterkategorien</option>';
+        const category = CATEGORY_OPTIONS.find(option => String(option.id) === String(categoryId));
+        if (category && category.subcategories) {
+          category.subcategories.forEach(sub => {
+            const opt = document.createElement('option');
+            opt.value = sub.id;
+            opt.textContent = sub.name;
+            if (String(sub.id) === String(selectedId)) {
+              opt.selected = true;
+            }
+            select.appendChild(opt);
+          });
+        }
+        return select;
+      }
+
+      function createRequirementRow(initial) {
+        const row = document.createElement('div');
+        row.className = 'card requirement-row';
+        row.style.padding = '1rem';
+        row.style.display = 'grid';
+        row.style.gridTemplateColumns = 'repeat(auto-fit, minmax(180px, 1fr))';
+        row.style.gap = '0.75rem';
+
+        const categoryField = document.createElement('div');
+        categoryField.className = 'form-field';
+        const categoryLabel = document.createElement('label');
+        categoryLabel.textContent = 'Kategorie';
+        const categorySelect = buildCategorySelect(initial?.category_id);
+        categoryField.append(categoryLabel, categorySelect);
+
+        const subcategoryField = document.createElement('div');
+        subcategoryField.className = 'form-field';
+        const subcategoryLabel = document.createElement('label');
+        subcategoryLabel.textContent = 'Unterkategorie';
+        const subcategorySelect = buildSubcategorySelect(initial?.category_id, initial?.subcategory_id);
+        subcategoryField.append(subcategoryLabel, subcategorySelect);
+
+        const countField = document.createElement('div');
+        countField.className = 'form-field';
+        const countLabel = document.createElement('label');
+        countLabel.textContent = 'Aufgaben';
+        const countInput = document.createElement('input');
+        countInput.type = 'number';
+        countInput.min = '1';
+        countInput.value = initial?.question_count || 1;
+        countInput.required = true;
+        countInput.dataset.role = 'count';
+        countField.append(countLabel, countInput);
+
+        const removeField = document.createElement('div');
+        removeField.className = 'form-field';
+        removeField.style.alignSelf = 'end';
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'button ghost small';
+        removeBtn.textContent = 'Entfernen';
+        removeBtn.addEventListener('click', () => {
+          row.remove();
+        });
+        removeField.append(removeBtn);
+
+        categorySelect.addEventListener('change', () => {
+          const current = subcategorySelect.value;
+          const nextSelect = buildSubcategorySelect(categorySelect.value, current);
+          nextSelect.dataset.role = 'subcategory';
+          subcategorySelect.replaceWith(nextSelect);
+        });
+
+        row.append(categoryField, subcategoryField, countField, removeField);
+        return row;
+      }
+
+      function addRequirement(initial) {
+        const row = createRequirementRow(initial);
+        listEl.appendChild(row);
+      }
+
+      addBtn.addEventListener('click', () => addRequirement());
+      addRequirement();
+
+      document.getElementById('configuration-form').addEventListener('submit', event => {
+        const rows = Array.from(listEl.querySelectorAll('.requirement-row'));
+        if (!rows.length) {
+          event.preventDefault();
+          alert('Bitte füge mindestens eine Kategorie hinzu.');
+          return;
+        }
+        const requirements = rows.map(row => {
+          const categorySelect = row.querySelector('[data-role="category"]');
+          const subcategorySelect = row.querySelector('[data-role="subcategory"]');
+          const countInput = row.querySelector('[data-role="count"]');
+          return {
+            category_id: categorySelect.value,
+            subcategory_id: subcategorySelect.value || null,
+            question_count: countInput.value || 1,
+          };
+        });
+        if (requirements.some(req => !req.category_id)) {
+          event.preventDefault();
+          alert('Bitte wähle für jede Zeile eine Kategorie aus.');
+          return;
+        }
+        requirementsInput.value = JSON.stringify(requirements);
+      });
+    })();
+  </script>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,109 +3,153 @@
 {% block title %}Übersicht · Examination Tool{% endblock %}
 
 {% block content %}
-  <section class="card">
-    <h2>Überblick</h2>
-    <p>Verwalte Studierende, Aufgaben und starte neue Prüfungssitzungen.</p>
-    <div class="stats-grid">
-      <div>
-        <strong>{{ tasks_count }}</strong>
-        <div>Aufgaben vorhanden</div>
-      </div>
-      <div>
-        <strong>{{ category_requirements|length }}</strong>
-        <div>Kategorien definiert</div>
-      </div>
-      <div>
-        <strong>{{ groups|length }}</strong>
-        <div>Gruppen verfügbar</div>
-      </div>
-    </div>
-  </section>
+  <h1 class="page-title">Übersicht</h1>
 
-  <section class="card">
-    <h2>Prüfung starten</h2>
-    {% if not groups %}
-      <p>Es wurden noch keine Studierenden importiert. Lade zuerst eine XLSX-Datei hoch.</p>
+  <div class="cards-row">
+    <div class="card">
+      <h2>Aufgaben</h2>
+      <div class="stat-value">{{ tasks_count }}</div>
+      <p class="text-muted">verfügbare Aufgaben in der Bibliothek</p>
+      <a class="accent-link" href="/tasks">Aufgaben verwalten →</a>
+    </div>
+    <div class="card">
+      <h2>Kategorien</h2>
+      <div class="stat-value">{{ category_tree|length }}</div>
+      <p class="text-muted">Hauptkategorien mit Unterstrukturen</p>
+      <a class="accent-link" href="/categories">Kategorien bearbeiten →</a>
+    </div>
+    <div class="card">
+      <h2>Gruppen</h2>
+      <div class="stat-value">{{ groups|length }}</div>
+      <p class="text-muted">importierte Teams und Partnerpaare</p>
+      <a class="accent-link" href="/students/import">Studierende importieren →</a>
+    </div>
+  </div>
+
+  <section class="section">
+    <div class="section-header">
+      <h2>Prüfungskonfigurationen</h2>
+      <a class="button small" href="/exam-configurations/new">Neue Konfiguration anlegen</a>
+    </div>
+    {% if not configurations %}
+      <div class="card config-card">
+        <p>Es wurden noch keine Prüfungskonfigurationen erstellt. Lege eine neue Konfiguration an, um festzulegen, welche Kategorien und wie viele Aufgaben pro Kategorie in einer Prüfung verwendet werden sollen.</p>
+        <a class="button secondary small" href="/exam-configurations/new">Jetzt konfigurieren</a>
+      </div>
     {% else %}
-      <p>Wähle eine Gruppe aus, um eine neue Prüfungssitzung zu erstellen. Es wird automatisch pro Kategorie eine zufällige Aufgabe ausgewählt.</p>
-      <table class="table">
-        <thead>
-          <tr>
-            <th>Gruppe</th>
-            <th>Studierende</th>
-            <th>Aktion</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for group in groups %}
-            <tr>
-              <td>{{ group.label }}</td>
-              <td>
-                {% for student in group.students %}
-                  {{ student.full_name }}{% if not loop.last %}, {% endif %}
-                {% endfor %}
-              </td>
-              <td>
-                <form method="post" action="/exams">
-                  <input type="hidden" name="group_id" value="{{ group.id }}" />
-                  <button type="submit">Prüfung starten</button>
+      <div class="task-grid">
+        {% for configuration in configurations %}
+          <article class="card config-card">
+            <header class="section-header" style="margin-bottom:0.5rem;">
+              <h3>{{ configuration.name }}</h3>
+              <form method="post" action="/exam-configurations/{{ configuration.id }}/delete" onsubmit="return confirm('Konfiguration wirklich löschen?');">
+                <button class="button ghost small" type="submit">Löschen</button>
+              </form>
+            </header>
+            <div class="config-meta">
+              <span class="chip">Ø Schwierigkeit {{ '%.1f' % configuration.target_difficulty }}</span>
+              <span class="badge">{{ configuration.requirements|length }} Kategorien</span>
+            </div>
+            <div class="config-card__requirements">
+              {% for requirement in configuration.requirements %}
+                <div>
+                  <strong>{{ requirement.category.name }}</strong>
+                  {% if requirement.subcategory %}· {{ requirement.subcategory.name }}{% endif %}
+                  <span class="badge">{{ requirement.question_count }} Frage(n)</span>
+                </div>
+              {% endfor %}
+            </div>
+            <div class="config-card__footer">
+              {% if has_groups %}
+                <form class="inline-form" method="post" action="/exams">
+                  <input type="hidden" name="configuration_id" value="{{ configuration.id }}" />
+                  <label for="config-{{ configuration.id }}-group">Gruppe</label>
+                  <select id="config-{{ configuration.id }}-group" name="group_id" required>
+                    <option value="" disabled selected>Gruppe wählen</option>
+                    {% for group in groups %}
+                      <option value="{{ group.id }}">{{ group.label }}</option>
+                    {% endfor %}
+                  </select>
+                  <button class="button small" type="submit">Prüfung starten</button>
                 </form>
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+              {% else %}
+                <p class="text-muted">Noch keine Gruppen importiert. Verwende den Demomodus, um die Studierendenansicht zu testen.</p>
+              {% endif %}
+              <form class="inline-form" method="post" action="/exams">
+                <input type="hidden" name="configuration_id" value="{{ configuration.id }}" />
+                <input type="hidden" name="group_id" value="" />
+                <label for="demo-{{ configuration.id }}">Demomodus</label>
+                <input id="demo-{{ configuration.id }}" type="text" name="demo_label" value="Testmodus" />
+                <button class="button secondary small" type="submit">Demo öffnen</button>
+              </form>
+            </div>
+          </article>
+        {% endfor %}
+      </div>
     {% endif %}
   </section>
 
-  <section class="card">
-    <h2>Studierendenansicht</h2>
-    <p>Nutze diesen Link, um die Ansicht für Studierende auf einem separaten Bildschirm anzuzeigen. Bei neuen Prüfungen aktualisiert sich die Ansicht automatisch.</p>
-    <code class="share-link">{{ student_live_url }}</code>
-    <div class="task-metadata" style="margin-top:0.5rem;">
-      {% if active_exam %}
-        Aktive Prüfung: {{ active_exam.group.label }} (gestartet am {{ active_exam.started_at.strftime('%d.%m.%Y %H:%M') }} Uhr)
+  <section class="section">
+    <div class="section-header">
+      <h2>Kategorien &amp; Struktur</h2>
+    </div>
+    <div class="category-tree">
+      {% if not category_tree %}
+        <p>Es wurden noch keine Kategorien definiert. Lege Haupt- und Unterkategorien an, um Aufgaben übersichtlich zu strukturieren.</p>
       {% else %}
-        Aktuell ist keine Prüfung aktiv.
+        <ul>
+          {% for category in category_tree %}
+            <li>
+              <strong>{{ category.name }}</strong>
+              {% if category.children %}
+                <ul>
+                  {% for subcategory in category.children %}
+                    <li>{{ subcategory.name }}</li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
       {% endif %}
     </div>
-    <a class="button secondary" href="{{ student_live_url }}" target="_blank">Studierendenansicht öffnen</a>
   </section>
 
-  <section class="card">
-    <h2>Kategorien</h2>
-    {% if not category_tree %}
-      <p>Definiere Kategorien, um die Auswahl der Aufgaben zu steuern.</p>
-    {% else %}
-      <ul class="category-summary">
-        {% for category in category_tree %}
-          {% set requirement = requirements_map.get(category.name) %}
-          <li>
-            <strong>{{ category.name }}</strong>
-            {% if requirement %}
-              · {{ requirement.required_count }} Aufgabe(n)
-            {% endif %}
-            {% if category.children %}
-              <ul>
-                {% for subcategory in category.children %}
-                  <li>{{ subcategory.name }}</li>
-                {% endfor %}
-              </ul>
-            {% endif %}
-          </li>
-        {% endfor %}
-      </ul>
-    {% endif %}
+  <section class="section">
+    <div class="section-header">
+      <h2>Studierendenansicht</h2>
+    </div>
+      <div class="card">
+        <p>Nutze diesen Link, um die Liveansicht für Studierende bereitzustellen. Die aktuell aktive Prüfung wird dort automatisch angezeigt.</p>
+        <code class="share-link">{{ student_live_url }}</code>
+        <div class="task-card__meta" style="margin-top:0.75rem;">
+          {% if active_exam %}
+          Aktive Prüfung: {{ active_exam.configuration.name if active_exam.configuration else 'Konfiguration unbekannt' }}{% if active_exam.group %} · {{ active_exam.group.label }}{% endif %} (gestartet am {{ active_exam.started_at.strftime('%d.%m.%Y %H:%M') }} Uhr)
+          {% else %}
+          Aktuell ist keine Prüfung aktiv.
+          {% endif %}
+        </div>
+        <a class="button secondary" href="{{ student_live_url }}" target="_blank" rel="noopener">Studierendenansicht öffnen</a>
+    </div>
   </section>
 
   {% if latest_exam %}
-    <section class="card">
-      <h2>Letzte Prüfung</h2>
-      <p>
-        Gruppe <strong>{{ latest_exam.group.label }}</strong> &middot;
-        gestartet am {{ latest_exam.started_at.strftime('%d.%m.%Y %H:%M') }} Uhr
-      </p>
-      <a class="button secondary" href="/exams/{{ latest_exam.id }}/teacher">Prüfung ansehen</a>
+    <section class="section">
+      <div class="section-header">
+        <h2>Letzte Prüfung</h2>
+      </div>
+      <div class="card">
+        <p>
+          {% if latest_exam.group %}
+            Gruppe <strong>{{ latest_exam.group.label }}</strong>
+          {% else %}
+            <strong>Demomodus</strong>
+          {% endif %}
+          · {{ latest_exam.configuration.name if latest_exam.configuration else 'ohne Konfiguration' }}
+          · gestartet am {{ latest_exam.started_at.strftime('%d.%m.%Y %H:%M') }} Uhr
+        </p>
+        <a class="button secondary" href="/exams/{{ latest_exam.id }}/teacher">Prüfung ansehen</a>
+      </div>
     </section>
   {% endif %}
 {% endblock %}

--- a/app/templates/tasks_form.html
+++ b/app/templates/tasks_form.html
@@ -8,53 +8,68 @@
 
 {% block title %}{{ page_title }} · Examination Tool{% endblock %}
 
+{% block head_extra %}
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/cropperjs@1.6.1/dist/cropper.min.css"
+  />
+{% endblock %}
+
 {% block content %}
-  <section class="card">
-    <h2>{{ page_title }}</h2>
-    {% if not categories %}
-      <p class="alert warning">
-        Es wurden noch keine Kategorien definiert. Lege zunächst Kategorien an, bevor du Aufgaben erstellst.
-      </p>
-    {% endif %}
+  <h1 class="page-title">{{ page_title }}</h1>
+
+  <div class="form-card">
     <form
       id="task-form"
       method="post"
       enctype="multipart/form-data"
       action="{% if task %}/tasks/{{ task.id }}{% else %}/tasks{% endif %}"
     >
-      <div class="form-row">
-        <label for="title">Titel</label>
-        <input id="title" type="text" name="title" value="{{ task.title if task else '' }}" required />
-      </div>
-      <div class="form-row">
-        <label for="category_id">Kategorie</label>
-        <select id="category_id" name="category_id" required>
-          <option value="" disabled {% if not selected_category_id %}selected{% endif %}>Kategorie wählen</option>
-          {% for category in categories %}
-            <option value="{{ category.id }}" {% if selected_category_id == category.id %}selected{% endif %}>{{ category.name }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      <div class="form-row">
-        <label for="subcategory_id">Unterkategorie</label>
-        <select
-          id="subcategory_id"
-          name="subcategory_id"
-          data-selected="{{ selected_subcategory_id if selected_subcategory_id else '' }}"
-        >
-          <option value="" {% if not selected_subcategory_id %}selected{% endif %}>Keine Unterkategorie</option>
-          {% if selected_category_id %}
+      <input type="hidden" name="crop_metadata" id="crop-metadata" />
+      <div class="form-grid">
+        <div class="form-field">
+          <label for="title">Titel</label>
+          <input id="title" type="text" name="title" value="{{ task.title if task else '' }}" required />
+        </div>
+        <div class="form-field">
+          <label for="category_id">Kategorie</label>
+          <select id="category_id" name="category_id" required>
+            <option value="" disabled {% if not selected_category_id %}selected{% endif %}>Kategorie wählen</option>
             {% for category in categories %}
-              {% if category.id == selected_category_id %}
-                {% for subcategory in category.children %}
-                  <option value="{{ subcategory.id }}" {% if selected_subcategory_id == subcategory.id %}selected{% endif %}>{{ subcategory.name }}</option>
-                {% endfor %}
-              {% endif %}
+              <option value="{{ category.id }}" {% if selected_category_id == category.id %}selected{% endif %}>{{ category.name }}</option>
             {% endfor %}
-          {% endif %}
-        </select>
+          </select>
+        </div>
+        <div class="form-field">
+          <label for="subcategory_id">Unterkategorie</label>
+          <select
+            id="subcategory_id"
+            name="subcategory_id"
+            data-selected="{{ selected_subcategory_id if selected_subcategory_id else '' }}"
+          >
+            <option value="" {% if not selected_subcategory_id %}selected{% endif %}>Keine Unterkategorie</option>
+            {% if selected_category_id %}
+              {% for category in categories %}
+                {% if category.id == selected_category_id %}
+                  {% for subcategory in category.children %}
+                    <option value="{{ subcategory.id }}" {% if selected_subcategory_id == subcategory.id %}selected{% endif %}>{{ subcategory.name }}</option>
+                  {% endfor %}
+                {% endif %}
+              {% endfor %}
+            {% endif %}
+          </select>
+        </div>
+        <div class="form-field">
+          <label for="difficulty">Schwierigkeitsstufe</label>
+          <select id="difficulty" name="difficulty" required>
+            <option value="1" {% if task and task.difficulty == 1 %}selected{% endif %}>1 · Grundlagen</option>
+            <option value="2" {% if not task or task.difficulty == 2 %}selected{% endif %}>2 · Fortgeschritten</option>
+            <option value="3" {% if task and task.difficulty == 3 %}selected{% endif %}>3 · Anspruchsvoll</option>
+          </select>
+        </div>
       </div>
-      <div class="form-row markdown-editor">
+
+      <div class="form-field markdown-editor">
         <label for="statement_markdown">Aufgabe (Markdown)</label>
         <div class="markdown-editor-grid">
           <textarea
@@ -66,8 +81,9 @@
           <div class="markdown-preview" id="statement-preview"></div>
         </div>
       </div>
-      <div class="form-row markdown-editor">
-        <label for="hints_markdown">Hinweise (Markdown, optional)</label>
+
+      <div class="form-field markdown-editor">
+        <label for="hints_markdown">Hinweise (optional)</label>
         <div class="markdown-editor-grid">
           <textarea
             id="hints_markdown"
@@ -77,8 +93,9 @@
           <div class="markdown-preview" id="hints-preview"></div>
         </div>
       </div>
-      <div class="form-row markdown-editor">
-        <label for="solution_markdown">Lösung (Markdown, optional)</label>
+
+      <div class="form-field markdown-editor">
+        <label for="solution_markdown">Lösung (optional)</label>
         <div class="markdown-editor-grid">
           <textarea
             id="solution_markdown"
@@ -88,55 +105,76 @@
           <div class="markdown-preview" id="solution-preview"></div>
         </div>
       </div>
-      <div class="form-row">
-        <label for="dependency_ids">Abhängigkeiten (IDs, durch Komma getrennt)</label>
+
+      <div class="form-field">
+        <label for="dependency_ids">Abhängigkeiten (IDs, Komma getrennt)</label>
         <input
           id="dependency_ids"
           type="text"
           name="dependency_ids"
           value="{% if task and task.dependencies %}{% for dep in task.dependencies %}{{ dep.id }}{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}"
+          placeholder="z. B. 12, 18"
         />
-        <small class="task-metadata">Wähle IDs aus der folgenden Liste, falls die Aufgabe von anderen Aufgaben abhängig ist.</small>
       </div>
-      <div class="form-row">
+
+      <div class="form-field">
         <label for="images">Anhänge (Bilder)</label>
         <input id="images" type="file" name="images" accept="image/*" multiple />
-        <small class="task-metadata">Unterstützt PNG, JPG und andere gängige Bildformate. Mehrere Dateien können gleichzeitig ausgewählt werden.</small>
+        <small class="text-muted">Bilder werden automatisch auf 4:3 zugeschnitten und auf 1200×900 px skaliert.</small>
+        <div class="task-media-preview" id="image-preview"></div>
       </div>
+
       {% if task and task.images %}
-        <div class="form-row">
+        <div class="form-field">
           <label>Vorhandene Bilder</label>
           <div class="image-gallery">
             {% for image in task.images %}
-              <div class="image-gallery-item">
-                <img src="{{ url_for('static', path=image.file_path) }}" alt="{{ image.original_filename }}" />
+              <figure>
+                <img src="{{ url_for('static', path=image.thumbnail_path or image.file_path) }}" alt="{{ image.original_filename }}" />
+                <figcaption>{{ image.original_filename }}</figcaption>
                 <label class="remove-toggle">
-                  <input type="checkbox" name="remove_image_ids" value="{{ image.id }}" />
-                  Entfernen
+                  <input type="checkbox" name="remove_image_ids" value="{{ image.id }}" /> Entfernen
                 </label>
-                <div class="task-metadata">{{ image.original_filename }}</div>
-              </div>
+              </figure>
             {% endfor %}
           </div>
         </div>
       {% endif %}
+
       {% if all_tasks %}
-        <div class="form-row">
+        <div class="form-field">
           <label>Verfügbare Aufgaben</label>
-          <div class="task-metadata">
+          <div class="markdown-preview" style="max-height:180px; overflow:auto;">
             {% for other in all_tasks %}
               #{{ other.id }} · {{ other.title }} ({{ other.category }})<br />
             {% endfor %}
           </div>
         </div>
       {% endif %}
-      <button type="submit">Speichern</button>
-      <a class="button secondary" href="/tasks">Abbrechen</a>
+
+      <div class="form-actions">
+        <a class="button ghost" href="/tasks">Abbrechen</a>
+        <button type="submit" class="button">Speichern</button>
+      </div>
     </form>
-  </section>
+  </div>
+
+  <div class="modal" id="crop-modal" role="dialog" aria-modal="true" aria-labelledby="crop-modal-title">
+    <div class="modal__content">
+      <h3 id="crop-modal-title">Bild zuschneiden</h3>
+      <div class="crop-container">
+        <img id="crop-image" alt="Vorschau zum Zuschnitt" />
+      </div>
+      <div class="modal__actions">
+        <button type="button" class="button ghost" id="crop-cancel">Abbrechen</button>
+        <button type="button" class="button" id="crop-apply">Zuschnitt übernehmen</button>
+      </div>
+    </div>
+  </div>
 {% endblock %}
 
 {% block scripts %}
+  <script src="https://cdn.jsdelivr.net/npm/cropperjs@1.6.1/dist/cropper.min.js"></script>
   <script>
     const categoryOptions = {{ category_options_json | safe }};
     const categorySelect = document.getElementById('category_id');
@@ -200,37 +238,137 @@
         try {
           const response = await fetch('/api/markdown/preview', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ content }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
             signal: abortController.signal,
+            body: JSON.stringify({ markdown: content }),
           });
           if (!response.ok) {
-            throw new Error('Fehler bei der Vorschau');
+            throw new Error('Fehler beim Rendern der Vorschau');
           }
-          const payload = await response.json();
-          previewElement.innerHTML = payload.html || '';
-          if (window.MathJax && window.MathJax.typesetPromise) {
-            window.MathJax.typesetPromise([previewElement]);
-          }
+          const data = await response.json();
+          previewElement.innerHTML = data.html || '';
         } catch (error) {
-          if (error.name === 'AbortError') {
-            return;
+          if (error.name !== 'AbortError') {
+            console.error(error);
           }
-          previewElement.innerHTML = '<p class="task-metadata">Keine Vorschau verfügbar.</p>';
         }
       }
 
-      const scheduleRender = () => {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
-        timeoutId = setTimeout(renderPreview, 250);
-      };
+      textarea.addEventListener('input', () => {
+        clearTimeout(timeoutId);
+        timeoutId = window.setTimeout(renderPreview, 250);
+      });
 
-      textarea.addEventListener('input', scheduleRender);
       renderPreview();
     }
 
-    document.querySelectorAll('.markdown-editor textarea').forEach(setupMarkdownPreview);
+    document.querySelectorAll('[data-preview-target]').forEach(setupMarkdownPreview);
+
+    // Bildzuschnitt
+    const imageInput = document.getElementById('images');
+    const previewContainer = document.getElementById('image-preview');
+    const cropModal = document.getElementById('crop-modal');
+    const cropImage = document.getElementById('crop-image');
+    const cropApply = document.getElementById('crop-apply');
+    const cropCancel = document.getElementById('crop-cancel');
+    const cropMetadataField = document.getElementById('crop-metadata');
+
+    const cropQueue = [];
+    const cropMetadata = {};
+    let cropper = null;
+
+    function openModal() {
+      cropModal.classList.add('is-open');
+    }
+
+    function closeModal() {
+      cropModal.classList.remove('is-open');
+      if (cropper) {
+        cropper.destroy();
+        cropper = null;
+      }
+    }
+
+    function processNextCrop() {
+      if (!cropQueue.length) {
+        closeModal();
+        return;
+      }
+      const current = cropQueue.shift();
+      cropImage.src = current.dataUrl;
+      openModal();
+      requestAnimationFrame(() => {
+        cropper = new Cropper(cropImage, {
+          aspectRatio: 4 / 3,
+          viewMode: 1,
+          autoCropArea: 1,
+        });
+        cropApply.onclick = () => {
+          const data = cropper.getData();
+          cropMetadata[current.file.name] = {
+            x: data.x,
+            y: data.y,
+            width: data.width,
+            height: data.height,
+          };
+          closeModal();
+          processNextCrop();
+        };
+        cropCancel.onclick = () => {
+          delete cropMetadata[current.file.name];
+          closeModal();
+          processNextCrop();
+        };
+      });
+    }
+
+    function queueCrop(file, dataUrl) {
+      cropQueue.push({ file, dataUrl });
+      if (!cropper && !cropModal.classList.contains('is-open')) {
+        processNextCrop();
+      }
+    }
+
+    function handleFilePreview(file, dataUrl, needsCrop) {
+      const img = document.createElement('img');
+      img.src = dataUrl;
+      img.alt = file.name;
+      previewContainer.appendChild(img);
+      if (!needsCrop) {
+        delete cropMetadata[file.name];
+      }
+    }
+
+    if (imageInput) {
+      imageInput.addEventListener('change', () => {
+        previewContainer.innerHTML = '';
+        cropQueue.length = 0;
+        closeModal();
+        Object.keys(cropMetadata).forEach((key) => delete cropMetadata[key]);
+        Array.from(imageInput.files || []).forEach((file) => {
+          const reader = new FileReader();
+          reader.onload = (event) => {
+            const dataUrl = event.target.result;
+            const img = new Image();
+            img.onload = () => {
+              const ratio = img.width / img.height;
+              const needsCrop = Math.abs(ratio - 4 / 3) > 0.02;
+              handleFilePreview(file, dataUrl, needsCrop);
+              if (needsCrop) {
+                queueCrop(file, dataUrl);
+              }
+            };
+            img.src = dataUrl;
+          };
+          reader.readAsDataURL(file);
+        });
+      });
+    }
+
+    document.getElementById('task-form').addEventListener('submit', () => {
+      cropMetadataField.value = JSON.stringify(cropMetadata);
+    });
   </script>
 {% endblock %}

--- a/app/templates/tasks_list.html
+++ b/app/templates/tasks_list.html
@@ -3,81 +3,59 @@
 {% block title %}Aufgaben · Examination Tool{% endblock %}
 
 {% block content %}
-  <section class="card">
-    <div class="task-toolbar">
-      <h2>Aufgaben</h2>
-      <div class="task-toolbar-actions">
-        <a class="button" href="/tasks/new">Neue Aufgabe</a>
-        <a class="button secondary" href="/tasks/export">JSON exportieren</a>
-        <form id="task-import-form" method="post" action="/tasks/import" enctype="multipart/form-data">
-          <label for="import-file" class="button secondary">JSON importieren</label>
-          <input id="import-file" type="file" name="upload" accept="application/json" required />
-        </form>
-      </div>
+  <div class="section-header">
+    <h1 class="page-title">Aufgabenbibliothek</h1>
+    <div>
+      <a class="button secondary" href="/tasks/export">Exportieren</a>
+      <a class="button" href="/tasks/new">Neue Aufgabe</a>
     </div>
-    {% if import_summary %}
-      <p class="alert success">
-        Import abgeschlossen:
-        {{ import_summary.tasks }} Aufgabe(n), {{ import_summary.categories }} Kategorie(n),
-        {{ import_summary.subcategories }} Unterkategorie(n) und {{ import_summary.images }} Bild(er) verarbeitet.
-      </p>
-    {% endif %}
-    {% if not tasks %}
-      <p>Noch keine Aufgaben vorhanden. Lege die erste Aufgabe an, um Prüfungen erstellen zu können.</p>
-    {% else %}
+  </div>
+
+  {% if import_summary %}
+    <div class="alert success">
+      Import erfolgreich: {{ import_summary.tasks }} Aufgaben, {{ import_summary.categories }} Kategorien, {{ import_summary.subcategories }} Unterkategorien, {{ import_summary.images }} Bilder.
+    </div>
+  {% endif %}
+
+  {% if not tasks %}
+    <div class="card">
+      <p>Noch keine Aufgaben vorhanden. Lege eine neue Aufgabe an oder importiere vorhandene Datensätze.</p>
+    </div>
+  {% else %}
+    <div class="task-grid">
       {% for item in tasks %}
         {% set task = item.task %}
         <article class="task-card">
-          <header>
-            <h3>#{{ task.id }} · {{ task.title }}</h3>
-            <div class="task-metadata">Kategorie: {{ task.category }}{% if task.subcategory %} &middot; Unterkategorie: {{ task.subcategory }}{% endif %}</div>
-          </header>
-          <div class="task-body">
-            <h4 class="section-title">Aufgabe</h4>
-            <div class="markdown">{{ item.statement_html | safe }}</div>
+          <div class="task-card__image">
             {% if task.images %}
-              <div class="task-images">
-                {% for image in task.images %}
-                  <figure>
-                    <img src="{{ url_for('static', path=image.file_path) }}" alt="{{ image.original_filename }}" />
-                    <figcaption>{{ image.original_filename }}</figcaption>
-                  </figure>
-                {% endfor %}
-              </div>
-            {% endif %}
-            {% if item.hints_html %}
-              <h4 class="section-title">Hinweise</h4>
-              <div class="markdown">{{ item.hints_html | safe }}</div>
-            {% endif %}
-            {% if item.solution_html %}
-              <h4 class="section-title">Lösung</h4>
-              <div class="markdown">{{ item.solution_html | safe }}</div>
+              {% set image = task.images[0] %}
+              <img src="{{ url_for('static', path=image.thumbnail_path or image.file_path) }}" alt="Vorschaubild zu {{ task.title }}" />
+            {% else %}
+              <div class="task-card__placeholder">Schwierigkeit {{ task.difficulty }}</div>
             {% endif %}
           </div>
-          <footer style="margin-top:1rem; display:flex; gap:0.5rem;">
-            <a class="button secondary" href="/tasks/{{ task.id }}/edit">Bearbeiten</a>
-            <form method="post" action="/tasks/{{ task.id }}/delete" onsubmit="return confirm('Aufgabe wirklich löschen?');">
-              <button type="submit" class="danger">Löschen</button>
-            </form>
-            {% if task.dependencies %}
-              <span class="task-metadata">Abhängigkeiten: {% for dep in task.dependencies %}#{{ dep.id }}{% if not loop.last %}, {% endif %}{% endfor %}</span>
-            {% endif %}
-          </footer>
+          <div class="task-card__body">
+            <div class="task-card__meta">
+              <span class="badge">{{ task.category }}{% if task.subcategory %} · {{ task.subcategory }}{% endif %}</span>
+              <span class="chip chip--level-{{ task.difficulty }}">Schwierigkeit {{ task.difficulty }}</span>
+              {% if task.dependencies %}
+                <span class="badge">Voraussetzungen: {{ task.dependencies|length }}</span>
+              {% endif %}
+            </div>
+            <h3 class="task-card__title">{{ task.title }}</h3>
+            <div class="markdown-preview" style="max-height:180px; overflow:auto;">{{ item.statement_html|safe }}</div>
+            <div class="task-card__actions">
+              <a class="button secondary small" href="/tasks/{{ task.id }}/edit">Bearbeiten</a>
+              <form method="post" action="/tasks/{{ task.id }}/copy">
+                <button class="button small" type="submit">Kopie erstellen</button>
+              </form>
+              <form method="post" action="/tasks/{{ task.id }}/delete" onsubmit="return confirm('Aufgabe wirklich löschen?');">
+                <button class="button danger small" type="submit">Löschen</button>
+              </form>
+            </div>
+          </div>
         </article>
       {% endfor %}
-    {% endif %}
-  </section>
-{% endblock %}
-
-{% block scripts %}
-  <script>
-    const importInput = document.getElementById('import-file');
-    if (importInput) {
-      importInput.addEventListener('change', () => {
-        if (importInput.files.length) {
-          importInput.form.submit();
-        }
-      });
-    }
-  </script>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ markdown==3.6
 bleach==6.1.0
 pytest==8.1.1
 httpx==0.27.0
+Pillow==10.3.0


### PR DESCRIPTION
## Summary
- replace the legacy interface with Material-inspired layouts, card-based task listings, and reorganized category management
- introduce exam configurations, task difficulty levels, task duplication, and demo-mode exam sessions with updated exam generation logic
- add image processing with enforced 4:3 crops, thumbnails, and resilient import/export handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4533cd2f4832ca341fed63301d643