### PR TITLE
Revamp UI with Material Design enhancements

### DIFF
--- a/app/services/exam_service.py
+++ b/app/services/exam_service.py
@@ -218,6 +218,7 @@ def build_exam_payload(exam: ExamSession, include_solutions: bool) -> dict:
                 if include_solutions
                 else None,
                 "position": assignment.position,
+                "difficulty": task.difficulty,
                 "image_urls": [f"/static/{image.file_path}" for image in task.images],
             }
         )

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,0 +1,134 @@
+(function () {
+  function debounce(fn, delay = 250) {
+    let handle;
+    return function (...args) {
+      clearTimeout(handle);
+      handle = setTimeout(() => fn.apply(this, args), delay);
+    };
+  }
+
+  function initSidenavs() {
+    const sidenavs = document.querySelectorAll('.sidenav');
+    if (sidenavs.length && window.M && M.Sidenav) {
+      M.Sidenav.init(sidenavs, {});
+    }
+  }
+
+  function initSelects(scope = document) {
+    if (!window.M || !M.FormSelect) {
+      return;
+    }
+    const selects = scope.querySelectorAll('select');
+    selects.forEach((select) => {
+      const existing = window.M.FormSelect.getInstance(select);
+      if (select.dataset.mInitialized && existing) {
+        return;
+      }
+      if (existing) {
+        existing.destroy();
+      }
+      window.M.FormSelect.init(select);
+      select.dataset.mInitialized = 'true';
+    });
+  }
+
+  function initTextareas(scope = document) {
+    if (!window.M || !M.textareaAutoResize) {
+      return;
+    }
+    const textareas = scope.querySelectorAll('textarea.materialize-textarea');
+    textareas.forEach((textarea) => {
+      M.textareaAutoResize(textarea);
+    });
+    if (M.updateTextFields) {
+      M.updateTextFields();
+    }
+  }
+
+  async function renderMarkdown(textarea, preview) {
+    const content = textarea.value.trim();
+    if (!content) {
+      preview.innerHTML = '<span class="text-muted">Noch keine Inhalte eingegeben.</span>';
+      return;
+    }
+    preview.innerHTML = '<span class="text-muted">Vorschau wird geladen...</span>';
+    try {
+      const response = await fetch('/api/markdown/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+      });
+      if (!response.ok) {
+        throw new Error('Serverfehler');
+      }
+      const payload = await response.json();
+      preview.innerHTML = payload.html || '<span class="text-muted">Keine Vorschau verfügbar.</span>';
+      if (window.MathJax && window.MathJax.typesetPromise) {
+        window.MathJax.typesetPromise([preview]);
+      }
+    } catch (error) {
+      preview.innerHTML = '<span class="text-muted">Vorschau konnte nicht geladen werden.</span>';
+      console.error('Markdown preview failed', error);
+    }
+  }
+
+  function initMarkdownEditors() {
+    const editors = document.querySelectorAll('textarea[data-preview-target]');
+    editors.forEach((textarea) => {
+      const previewId = textarea.dataset.previewTarget;
+      const preview = previewId ? document.getElementById(previewId) : null;
+      if (!preview) {
+        return;
+      }
+      const updatePreview = debounce(() => renderMarkdown(textarea, preview), 300);
+      textarea.addEventListener('input', updatePreview);
+      updatePreview();
+    });
+  }
+
+  function initDifficultySegments() {
+    document.querySelectorAll('.difficulty-segmented').forEach((segment) => {
+      const targetInputId = segment.dataset.targetInput;
+      const hiddenInput = targetInputId ? document.getElementById(targetInputId) : null;
+      const display = segment.dataset.displayTarget
+        ? document.getElementById(segment.dataset.displayTarget)
+        : null;
+      if (!hiddenInput) {
+        return;
+      }
+      segment.querySelectorAll('input[type="radio"]').forEach((radio) => {
+        radio.addEventListener('change', () => {
+          hiddenInput.value = radio.value;
+          if (display) {
+            display.textContent = radio.dataset.label || `Stufe ${radio.value}`;
+          }
+        });
+      });
+
+      const checked = segment.querySelector('input[type="radio"]:checked');
+      if (checked) {
+        hiddenInput.value = checked.value;
+        if (display) {
+          display.textContent = checked.dataset.label || `Stufe ${checked.value}`;
+        }
+      }
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    initSidenavs();
+    initSelects();
+    initTextareas();
+    initMarkdownEditors();
+    initDifficultySegments();
+  });
+
+  window.AppUI = {
+    initSelects,
+    initTextareas,
+    refresh(scope = document) {
+      initSelects(scope);
+      initTextareas(scope);
+    },
+  };
+})();

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,550 +1,530 @@
 :root {
   color-scheme: light;
   font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
-  --primary: #2563eb;
-  --primary-dark: #1d4ed8;
-  --surface: #ffffff;
-  --surface-alt: #f5f6fb;
-  --text: #111827;
-  --muted: #6b7280;
-  --border: #e5e7eb;
-  --success: #16a34a;
-  --danger: #dc2626;
-  --shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+  --md-sys-color-primary: #3949ab;
+  --md-sys-color-primary-dark: #283593;
+  --md-sys-color-on-primary: #ffffff;
+  --md-sys-color-surface: #ffffff;
+  --md-sys-color-surface-variant: #f5f7fb;
+  --md-sys-color-outline: #d0d4e4;
+  --md-sys-color-text: #0f172a;
+  --md-sys-color-muted: #5f6c87;
+  --md-shadow-elevated: 0 20px 48px rgba(15, 23, 42, 0.12);
 }
 
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  background: var(--surface-alt);
-  color: var(--text);
+  background: var(--md-sys-color-surface-variant);
+  color: var(--md-sys-color-text);
 }
 
-a {
-  color: inherit;
+.app-nav {
+  background: var(--md-sys-color-surface);
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.12);
 }
 
-.app-bar {
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
-  position: sticky;
-  top: 0;
-  z-index: 20;
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
-}
-
-.app-bar__content {
-  max-width: 1200px;
-  margin: 0 auto;
-  display: flex;
+.app-nav .brand-logo {
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 1rem 1.5rem;
-  gap: 1rem;
-}
-
-.app-bar__brand {
-  font-weight: 700;
+  gap: 0.4rem;
   font-size: 1.25rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--primary);
-  text-decoration: none;
-}
-
-.app-bar__nav {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.app-bar__nav a {
-  text-decoration: none;
-  color: var(--muted);
   font-weight: 600;
-  padding: 0.35rem 0.6rem;
-  border-radius: 9999px;
-  transition: background 0.2s ease, color 0.2s ease;
+  color: var(--md-sys-color-primary);
 }
 
-.app-bar__nav a:hover,
-.app-bar__nav a:focus {
-  background: rgba(37, 99, 235, 0.12);
-  color: var(--primary);
+.app-nav .brand-logo .material-icons {
+  font-size: 1.6rem;
 }
 
-main {
-  padding: 2rem 1.5rem 3rem;
+.app-nav .sidenav-trigger {
+  color: var(--md-sys-color-primary);
 }
 
-.container {
-  max-width: 1200px;
-  margin: 0 auto;
+.sidenav {
+  background: #eef1fb;
+}
+
+.sidenav a {
+  color: var(--md-sys-color-text);
+  font-weight: 500;
+}
+
+.app-main {
+  padding: 3rem 0 4rem;
 }
 
 .page-title {
-  font-size: 2rem;
+  font-size: 2.25rem;
   font-weight: 700;
-  margin-bottom: 1.5rem;
-}
-
-.cards-row {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.25rem;
   margin-bottom: 2rem;
+  letter-spacing: -0.01em;
 }
 
-.card {
-  background: var(--surface);
-  border-radius: 1rem;
-  padding: 1.5rem;
-  box-shadow: var(--shadow);
-  border: 1px solid rgba(148, 163, 184, 0.15);
+.card,
+.card-panel {
+  border-radius: 1.25rem;
+  box-shadow: var(--md-shadow-elevated);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: var(--md-sys-color-surface);
 }
 
-.card h2 {
-  margin-top: 0;
-  font-size: 1.1rem;
+.card-panel {
+  padding: 2rem;
+}
+
+.card .card-title {
   font-weight: 600;
-  margin-bottom: 0.6rem;
-}
-
-.stat-value {
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: var(--primary);
+  font-size: 1.35rem;
 }
 
 .text-muted {
-  color: var(--muted);
-  font-size: 0.9rem;
+  color: var(--md-sys-color-muted);
 }
 
-.task-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 1.5rem;
-}
-
-.task-card {
-  background: var(--surface);
-  border-radius: 1rem;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  box-shadow: var(--shadow);
-  border: 1px solid rgba(148, 163, 184, 0.15);
-}
-
-.task-card__image {
-  position: relative;
-  padding-top: 56.25%;
-  background: rgba(37, 99, 235, 0.05);
-  overflow: hidden;
-}
-
-.task-card__image img {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.task-card__placeholder {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.btn,
+.btn-large {
+  border-radius: 999px;
   font-weight: 600;
-  color: var(--muted);
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(99, 102, 241, 0.12));
+  text-transform: none;
+  background: linear-gradient(135deg, var(--md-sys-color-primary), #5c6bc0);
 }
 
-.task-card__body {
-  padding: 1.25rem 1.5rem 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+.btn:hover,
+.btn-large:hover {
+  background: linear-gradient(135deg, var(--md-sys-color-primary-dark), #3f51b5);
 }
 
-.task-card__title {
-  font-size: 1.15rem;
-  font-weight: 600;
-  margin: 0;
-}
-
-.task-card__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  color: var(--muted);
-  font-size: 0.9rem;
-}
-
-.chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  background: rgba(37, 99, 235, 0.12);
-  color: var(--primary);
-  padding: 0.25rem 0.6rem;
-  border-radius: 9999px;
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-
-.chip--level-1 {
-  background: rgba(16, 185, 129, 0.12);
-  color: #047857;
-}
-
-.chip--level-2 {
-  background: rgba(37, 99, 235, 0.12);
-  color: var(--primary);
-}
-
-.chip--level-3 {
-  background: rgba(220, 38, 38, 0.12);
-  color: var(--danger);
-}
-
-.button,
-button {
-  appearance: none;
-  border: none;
-  border-radius: 9999px;
-  padding: 0.6rem 1.2rem;
-  font-weight: 600;
-  font-size: 0.95rem;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.35rem;
-  background: var(--primary);
-  color: white;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-
-.button:hover,
-button:hover,
-.button:focus,
-button:focus {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.2);
-}
-
-.button.secondary {
-  background: #475569;
-}
-
-.button.ghost {
+.btn.btn-flat,
+.btn-flat {
   background: transparent;
-  color: var(--muted);
-  border: 1px solid var(--border);
   box-shadow: none;
-}
-
-.button.danger {
-  background: var(--danger);
-}
-
-.button.small {
-  padding: 0.4rem 0.9rem;
-  font-size: 0.85rem;
-}
-
-.task-card__actions {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.section {
-  margin-bottom: 3rem;
-}
-
-.section-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1.25rem;
-  gap: 1rem;
-}
-
-.section-header h2 {
-  margin: 0;
-  font-size: 1.4rem;
-  font-weight: 700;
-}
-
-.form-card {
-  background: var(--surface);
-  border-radius: 1rem;
-  box-shadow: var(--shadow);
-  padding: 1.5rem;
-  border: 1px solid rgba(148, 163, 184, 0.15);
-}
-
-.form-grid {
-  display: grid;
-  gap: 1.25rem;
-}
-
-.form-field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.form-field label {
+  color: var(--md-sys-color-primary);
   font-weight: 600;
-  color: var(--muted);
-  font-size: 0.9rem;
 }
 
-.form-field input,
-.form-field textarea,
-.form-field select {
-  border: 1px solid var(--border);
-  border-radius: 0.75rem;
-  padding: 0.65rem 0.8rem;
-  font-size: 1rem;
-  font-family: inherit;
-  background: var(--surface-alt);
+.btn-flat:hover {
+  background: rgba(57, 73, 171, 0.1);
 }
 
-textarea {
-  min-height: 200px;
+.btn-danger {
+  background: linear-gradient(135deg, #e53935, #d81b60);
+}
+
+.btn-danger:hover {
+  background: linear-gradient(135deg, #c62828, #ad1457);
+}
+
+.btn-secondary {
+  background: linear-gradient(135deg, #5c6bc0, #7986cb);
 }
 
 .form-actions {
   display: flex;
-  justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 0.75rem;
+  margin-top: 1.5rem;
+  justify-content: flex-end;
 }
 
-.alert {
-  padding: 0.8rem 1rem;
-  border-radius: 0.75rem;
+.input-field label {
+  color: var(--md-sys-color-muted);
+}
+
+.input-field input[type='text'],
+.input-field input[type='number'],
+.input-field input[type='file'],
+.input-field select,
+textarea.materialize-textarea {
+  border-radius: 0.75rem !important;
+  border: 1px solid var(--md-sys-color-outline) !important;
+  padding: 0.9rem 1rem !important;
+  box-shadow: none !important;
+  background: #fff;
+}
+
+textarea.materialize-textarea {
+  min-height: 160px;
+  line-height: 1.5;
+}
+
+.input-field input:focus,
+.input-field select:focus,
+textarea.materialize-textarea:focus {
+  border-color: var(--md-sys-color-primary) !important;
+  box-shadow: 0 0 0 2px rgba(57, 73, 171, 0.2) !important;
+}
+
+.helper-text,
+small.helper-text {
+  color: var(--md-sys-color-muted) !important;
+}
+
+.form-card {
+  margin-bottom: 2rem;
+}
+
+.form-card .card-content {
+  padding: 2rem;
+}
+
+.markdown-editor-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.markdown-preview {
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 1px dashed rgba(57, 73, 171, 0.25);
+  background: rgba(236, 240, 253, 0.6);
+  min-height: 160px;
+  overflow: auto;
+}
+
+.markdown-preview h1,
+.markdown-preview h2,
+.markdown-preview h3,
+.markdown-preview h4,
+.markdown-preview h5,
+.markdown-preview h6 {
+  margin-top: 1.2rem;
+  margin-bottom: 0.6rem;
   font-weight: 600;
 }
 
-.alert.success {
-  background: rgba(34, 197, 94, 0.12);
-  color: var(--success);
-}
-
-.alert.error {
-  background: rgba(248, 113, 113, 0.15);
-  color: var(--danger);
+.markdown-preview p {
+  margin: 0.6rem 0;
 }
 
 .category-tree {
-  background: var(--surface);
-  border-radius: 1rem;
-  box-shadow: var(--shadow);
-  border: 1px solid rgba(148, 163, 184, 0.15);
-  padding: 1.5rem;
-}
-
-.category-tree ul {
-  list-style: none;
   margin: 0;
-  padding-left: 1rem;
-}
-
-.category-tree li {
-  margin-bottom: 0.5rem;
-  position: relative;
-  padding-left: 0.75rem;
-}
-
-.category-tree li::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0.6rem;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--primary);
-}
-
-.category-tree__actions {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  margin-top: 0.35rem;
-}
-
-.config-card {
-  display: flex;
-  flex-direction: column;
+  padding: 0;
+  list-style: none;
+  display: grid;
   gap: 1rem;
 }
 
-.config-card__requirements {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  font-size: 0.9rem;
-  color: var(--muted);
+.category-node {
+  border-radius: 1.1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1.4rem;
+  box-shadow: var(--md-shadow-elevated);
+  background: #fff;
 }
 
-.config-card__footer {
+.category-node__header {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 1rem;
   align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.category-node__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.category-node__children {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.category-node__child {
+  padding: 0.9rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(236, 240, 253, 0.6);
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .inline-form {
   display: flex;
-  gap: 0.6rem;
   flex-wrap: wrap;
+  gap: 0.75rem;
   align-items: center;
 }
 
-.inline-form select,
-.inline-form input[type='number'] {
-  border-radius: 0.75rem;
-  border: 1px solid var(--border);
-  padding: 0.5rem 0.7rem;
-  background: var(--surface-alt);
-}
-
-.config-meta {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  color: var(--muted);
-  font-size: 0.85rem;
-}
-
-.markdown-preview {
-  border-radius: 0.75rem;
-  background: var(--surface-alt);
-  border: 1px solid var(--border);
-  padding: 0.75rem;
-  min-height: 200px;
-}
-
-.image-gallery {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin-top: 0.75rem;
-}
-
-.image-gallery figure {
+.inline-form .input-field {
+  flex: 1 1 220px;
   margin: 0;
-  background: var(--surface-alt);
-  border-radius: 0.75rem;
-  padding: 0.75rem;
-  border: 1px solid var(--border);
-  max-width: 220px;
-}
-
-.image-gallery img {
-  width: 100%;
-  border-radius: 0.5rem;
-  object-fit: cover;
 }
 
 .badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.25rem 0.6rem;
-  border-radius: 9999px;
-  background: rgba(148, 163, 184, 0.18);
-  color: var(--muted);
-  font-size: 0.8rem;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(57, 73, 171, 0.12);
+  color: var(--md-sys-color-primary);
   font-weight: 600;
 }
 
-.modal {
-  position: fixed;
-  inset: 0;
-  background: rgba(15, 23, 42, 0.4);
-  backdrop-filter: blur(2px);
-  display: none;
-  align-items: center;
-  justify-content: center;
-  z-index: 50;
+.requirement-grid {
+  display: grid;
+  gap: 1rem;
 }
 
-.modal.is-open {
+.requirement-row {
+  border-radius: 1.1rem;
+  background: #f4f6ff;
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.requirement-actions {
   display: flex;
-}
-
-.modal__content {
-  background: var(--surface);
-  border-radius: 1rem;
-  padding: 1.5rem;
-  max-width: 640px;
-  width: 100%;
-  box-shadow: var(--shadow);
-}
-
-.modal__actions {
-  display: flex;
+  align-items: flex-end;
   justify-content: flex-end;
-  gap: 0.75rem;
-  margin-top: 1rem;
-}
-
-.crop-container {
-  max-height: 420px;
-  overflow: hidden;
-  border-radius: 0.75rem;
 }
 
 .task-media-preview {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
+  margin-top: 0.75rem;
 }
 
-.task-media-preview canvas,
-.task-media-preview img {
+.preview-thumb {
+  position: relative;
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  width: 180px;
+  min-height: 120px;
+  background: #fff;
+}
+
+.preview-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.preview-thumb .badge {
+  position: absolute;
+  left: 0.75rem;
+  bottom: 0.75rem;
+  box-shadow: 0 6px 16px rgba(57, 73, 171, 0.28);
+}
+
+.image-gallery {
+  margin-top: 1rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.image-gallery figure {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: #f4f6ff;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.image-gallery img {
+  width: 100%;
   border-radius: 0.75rem;
-  border: 1px solid var(--border);
-  max-width: 200px;
   object-fit: cover;
 }
 
-.accent-link {
-  color: var(--primary);
+.image-gallery figcaption {
+  font-size: 0.85rem;
+  color: var(--md-sys-color-muted);
+  text-align: center;
+}
+
+.remove-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   font-weight: 600;
-  text-decoration: none;
+  color: var(--md-sys-color-primary);
 }
 
-.accent-link:hover {
-  text-decoration: underline;
+.crop-container {
+  max-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 1rem;
 }
 
-@media (max-width: 768px) {
-  .app-bar__content {
-    flex-direction: column;
-    align-items: flex-start;
+.crop-container img {
+  max-width: 100%;
+  width: 100%;
+  height: auto;
+}
+
+.difficulty-segmented {
+  display: inline-flex;
+  width: 100%;
+  border-radius: 999px;
+  background: rgba(57, 73, 171, 0.12);
+  padding: 0.35rem;
+  gap: 0.35rem;
+}
+
+.difficulty-segmented input {
+  display: none;
+}
+
+.difficulty-segmented label {
+  flex: 1 1 0;
+  text-align: center;
+  padding: 0.6rem 0.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--md-sys-color-primary);
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.difficulty-segmented input:checked + label {
+  background: linear-gradient(135deg, var(--md-sys-color-primary), #5c6bc0);
+  color: var(--md-sys-color-on-primary);
+  box-shadow: 0 12px 24px rgba(60, 80, 180, 0.25);
+}
+
+.exam-task-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.exam-task-card {
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 1.75rem;
+  background: #fff;
+  box-shadow: var(--md-shadow-elevated);
+}
+
+.exam-task-card h2 {
+  margin-top: 0;
+  margin-bottom: 0.35rem;
+}
+
+.task-metadata {
+  font-size: 0.95rem;
+  color: var(--md-sys-color-muted);
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.task-images {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 1.25rem;
+}
+
+.task-images figure {
+  margin: 0;
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.task-images img {
+  width: 100%;
+  display: block;
+}
+
+.section-title {
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 0.4rem;
+  color: var(--md-sys-color-primary);
+}
+
+.alert {
+  padding: 1rem 1.2rem;
+  border-radius: 0.9rem;
+  background: rgba(57, 73, 171, 0.12);
+  color: var(--md-sys-color-primary);
+}
+
+.alert.error {
+  background: rgba(229, 57, 53, 0.12);
+  color: #c62828;
+}
+
+.exam-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.exam-toolbar code {
+  background: rgba(15, 23, 42, 0.08);
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.85rem;
+}
+
+.exam-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.exam-header__meta {
+  display: grid;
+  gap: 0.4rem;
+}
+
+@media (max-width: 992px) {
+  .markdown-editor-grid {
+    grid-template-columns: 1fr;
   }
 
-  .section-header {
+  .exam-header {
     flex-direction: column;
-    align-items: flex-start;
   }
 
-  .form-actions {
-    flex-direction: column;
-    align-items: stretch;
+  .exam-toolbar {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 600px) {
+  .card-panel {
+    padding: 1.5rem;
+  }
+
+  .page-title {
+    font-size: 1.85rem;
   }
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,7 +7,18 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+    />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"
+      integrity="sha512-1BM8w9Wm0K6UyjmOYGUWZAXgY0x0JBoYxKxO6jwxKF1u9IiMaTZGi4ZTSdKCbFf8gIuwZPzH0JwS4gS2y2zYKw=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
     />
     <link rel="stylesheet" href="{{ url_for('static', path='styles.css') }}" />
     <script>
@@ -31,26 +42,46 @@
     {% block head_extra %}{% endblock %}
   </head>
   <body>
-    <header class="app-bar">
-      <div class="app-bar__content">
-        <a class="app-bar__brand" href="/">
-          <span aria-hidden="true">📝</span>
-          Examination Tool
-        </a>
-        <nav class="app-bar__nav">
-          <a href="/">Übersicht</a>
-          <a href="/students/import">Studierende importieren</a>
-          <a href="/tasks">Aufgaben</a>
-          <a href="/categories">Kategorien</a>
-          <a href="/exam-configurations/new">Neue Prüfung</a>
-        </nav>
-      </div>
+    <header>
+      <nav class="z-depth-1 app-nav">
+        <div class="nav-wrapper container">
+          <a class="brand-logo" href="/">
+            <span class="material-icons" aria-hidden="true">draw</span>
+            Examination Tool
+          </a>
+          <a href="#" data-target="mobile-nav" class="sidenav-trigger" aria-label="Navigation öffnen">
+            <span class="material-icons">menu</span>
+          </a>
+          <ul class="right hide-on-med-and-down">
+            <li><a href="/">Übersicht</a></li>
+            <li><a href="/students/import">Studierende importieren</a></li>
+            <li><a href="/tasks">Aufgaben</a></li>
+            <li><a href="/categories">Kategorien</a></li>
+            <li><a href="/exam-configurations/new">Neue Prüfung</a></li>
+          </ul>
+        </div>
+      </nav>
+      <ul class="sidenav" id="mobile-nav">
+        <li><a href="/">Übersicht</a></li>
+        <li><a href="/students/import">Studierende importieren</a></li>
+        <li><a href="/tasks">Aufgaben</a></li>
+        <li><a href="/categories">Kategorien</a></li>
+        <li><a href="/exam-configurations/new">Neue Prüfung</a></li>
+      </ul>
     </header>
-    <main>
+    <main class="app-main">
       <div class="container">
         {% block content %}{% endblock %}
       </div>
     </main>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"
+      integrity="sha512-CZ6PvUCaY/0ZUqKoU0uUUtSRm4jOvrlesBxgVjbBc088DujzUyi4QxMauPDXmgZxziWSr0IkLk1q0sY1b02sxQ=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+      defer
+    ></script>
+    <script src="{{ url_for('static', path='app.js') }}" defer></script>
     {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/app/templates/categories.html
+++ b/app/templates/categories.html
@@ -5,63 +5,91 @@
 {% block content %}
   <h1 class="page-title">Kategorien verwalten</h1>
 
-  <div class="form-card" style="margin-bottom:2rem;">
+  <div class="card-panel form-card">
     <form method="post" action="/categories">
-      <div class="form-field">
-        <label for="new-category-name">Neue Hauptkategorie</label>
-        <input id="new-category-name" type="text" name="name" placeholder="z. B. Analysis" required />
-      </div>
-      <div class="form-actions">
-        <button class="button" type="submit">Kategorie anlegen</button>
+      <div class="row">
+        <div class="input-field col s12 m8">
+          <input id="new-category-name" type="text" name="name" required />
+          <label for="new-category-name">Neue Hauptkategorie</label>
+        </div>
+        <div class="col s12 m4 form-actions" style="margin-top: 0;">
+          <button class="btn waves-effect waves-light" type="submit">
+            <span class="material-icons left" aria-hidden="true">add</span>
+            Kategorie anlegen
+          </button>
+        </div>
       </div>
     </form>
   </div>
 
   {% if not categories %}
-    <div class="card">
-      <p>Noch keine Kategorien vorhanden. Lege eine erste Hauptkategorie an, um Aufgaben zu strukturieren.</p>
+    <div class="card-panel">
+      <p class="text-muted" style="margin: 0;">
+        Noch keine Kategorien vorhanden. Lege eine erste Hauptkategorie an, um Aufgaben zu strukturieren.
+      </p>
     </div>
   {% else %}
-    <div class="form-grid">
+    <ul class="category-tree">
       {% for category in categories %}
-        <article class="card">
-          <form class="inline-form" method="post" action="/categories">
-            <input type="hidden" name="category_id" value="{{ category.id }}" />
-            <label for="rename-{{ category.id }}">Kategorie</label>
-            <input id="rename-{{ category.id }}" name="name" type="text" value="{{ category.name }}" required />
-            <button class="button secondary small" type="submit">Umbenennen</button>
-          </form>
-
-          <div class="category-tree__actions">
-            <form class="inline-form" method="post" action="/categories/{{ category.id }}/subcategories">
-              <label for="new-sub-{{ category.id }}">Unterkategorie</label>
-              <input id="new-sub-{{ category.id }}" name="name" type="text" placeholder="Neue Unterkategorie" required />
-              <button class="button secondary small" type="submit">Hinzufügen</button>
+        <li class="category-node">
+          <div class="category-node__header">
+            <form class="inline-form" method="post" action="/categories">
+              <input type="hidden" name="category_id" value="{{ category.id }}" />
+              <div class="input-field" style="margin-bottom: 0;">
+                <input id="rename-{{ category.id }}" name="name" type="text" value="{{ category.name }}" required />
+                <label for="rename-{{ category.id }}" class="active">Kategorie</label>
+              </div>
+              <button class="btn btn-small btn-secondary waves-effect" type="submit">Umbenennen</button>
             </form>
-            <form method="post" action="/categories/{{ category.id }}/delete" onsubmit="return confirm('Kategorie wirklich löschen? Alle Unterkategorien werden ebenfalls entfernt.');">
-              <button class="button danger small" type="submit">Kategorie löschen</button>
+            <form
+              method="post"
+              action="/categories/{{ category.id }}/delete"
+              onsubmit="return confirm('Kategorie wirklich löschen? Alle Unterkategorien werden ebenfalls entfernt.');"
+            >
+              <button class="btn btn-small btn-danger waves-effect" type="submit">Kategorie löschen</button>
+            </form>
+          </div>
+
+          <div class="category-node__actions">
+            <form class="inline-form" method="post" action="/categories/{{ category.id }}/subcategories">
+              <div class="input-field" style="margin-bottom: 0;">
+                <input id="new-sub-{{ category.id }}" name="name" type="text" required />
+                <label for="new-sub-{{ category.id }}">Unterkategorie hinzufügen</label>
+              </div>
+              <button class="btn btn-small btn-secondary waves-effect" type="submit">Hinzufügen</button>
             </form>
           </div>
 
           {% if category.children %}
-            <ul class="category-tree" style="margin-top:1rem; border: none; box-shadow:none; padding:0;">
+            <ul class="category-node__children">
               {% for subcategory in category.children %}
-                <li>
-                  <form class="inline-form" method="post" action="/categories/{{ category.id }}/subcategories/{{ subcategory.id }}/rename">
-                    <input name="name" type="text" value="{{ subcategory.name }}" required />
-                    <button class="button secondary small" type="submit">Umbenennen</button>
+                <li class="category-node__child">
+                  <form
+                    class="inline-form"
+                    method="post"
+                    action="/categories/{{ category.id }}/subcategories/{{ subcategory.id }}/rename"
+                  >
+                    <div class="input-field" style="margin-bottom: 0;">
+                      <input name="name" id="rename-sub-{{ subcategory.id }}" type="text" value="{{ subcategory.name }}" required />
+                      <label for="rename-sub-{{ subcategory.id }}" class="active">Unterkategorie</label>
+                    </div>
+                    <button class="btn btn-small btn-secondary waves-effect" type="submit">Speichern</button>
                   </form>
-                  <form method="post" action="/categories/{{ category.id }}/subcategories/{{ subcategory.id }}/delete" onsubmit="return confirm('Unterkategorie wirklich löschen?');">
-                    <button class="button ghost small" type="submit">Entfernen</button>
+                  <form
+                    method="post"
+                    action="/categories/{{ category.id }}/subcategories/{{ subcategory.id }}/delete"
+                    onsubmit="return confirm('Unterkategorie wirklich löschen?');"
+                  >
+                    <button class="btn-flat waves-effect red-text text-darken-2" type="submit">Entfernen</button>
                   </form>
                 </li>
               {% endfor %}
             </ul>
           {% else %}
-            <p class="text-muted" style="margin-top:1rem;">Noch keine Unterkategorien angelegt.</p>
+            <p class="text-muted" style="margin-top: 1rem; margin-bottom: 0;">Noch keine Unterkategorien angelegt.</p>
           {% endif %}
-        </article>
+        </li>
       {% endfor %}
-    </div>
+    </ul>
   {% endif %}
 {% endblock %}

--- a/app/templates/exam_configuration_form.html
+++ b/app/templates/exam_configuration_form.html
@@ -5,33 +5,61 @@
 {% block content %}
   <h1 class="page-title">Neue Prüfungskonfiguration</h1>
 
-  <div class="form-card">
-    <form id="configuration-form" method="post" action="/exam-configurations">
-      <input type="hidden" name="requirements_json" id="requirements-json" />
-      <div class="form-grid">
-        <div class="form-field">
-          <label for="configuration-name">Name der Konfiguration</label>
-          <input id="configuration-name" name="name" type="text" placeholder="z. B. Abschlussklausur" required />
-        </div>
-        <div class="form-field">
-          <label for="target-difficulty">Durchschnittliches Schwierigkeitsniveau</label>
-          <input id="target-difficulty" name="target_difficulty" type="range" min="1" max="3" step="0.5" value="2" />
-          <div class="badge" id="target-difficulty-display">Stufe 2.0</div>
-        </div>
-      </div>
+  <div class="card form-card">
+    <div class="card-content">
+      <form id="configuration-form" method="post" action="/exam-configurations">
+        <input type="hidden" name="requirements_json" id="requirements-json" />
 
-      <div class="form-field">
-        <label>Kategorien &amp; Anzahl Aufgaben</label>
-        <p class="text-muted">Lege fest, aus welchen Kategorien wie viele Aufgaben automatisch gezogen werden sollen. Die Reihenfolge bestimmt zugleich die Priorität bei der Auswahl.</p>
-        <div id="requirements-list" class="form-grid"></div>
-        <button type="button" class="button secondary small" id="add-requirement">Kategorie hinzufügen</button>
-      </div>
+        <div class="row">
+          <div class="input-field col s12 m6">
+            <input id="configuration-name" name="name" type="text" placeholder="z. B. Abschlussklausur" required />
+            <label for="configuration-name">Name der Konfiguration</label>
+          </div>
+          <div class="input-field col s12 m6">
+            <label class="active" for="target-difficulty">Durchschnittliches Schwierigkeitsniveau</label>
+            <input type="hidden" id="target-difficulty" name="target_difficulty" value="2" />
+            <div
+              class="difficulty-segmented"
+              data-target-input="target-difficulty"
+              data-display-target="target-difficulty-display"
+            >
+              <input type="radio" name="difficulty-choice" id="difficulty-1" value="1" data-label="Stufe 1 – Grundlagen" />
+              <label for="difficulty-1">Stufe 1</label>
+              <input
+                type="radio"
+                name="difficulty-choice"
+                id="difficulty-2"
+                value="2"
+                data-label="Stufe 2 – Fortgeschritten"
+                checked
+              />
+              <label for="difficulty-2">Stufe 2</label>
+              <input type="radio" name="difficulty-choice" id="difficulty-3" value="3" data-label="Stufe 3 – Anspruchsvoll" />
+              <label for="difficulty-3">Stufe 3</label>
+            </div>
+            <span class="helper-text" id="target-difficulty-display">Stufe 2 – Fortgeschritten</span>
+          </div>
+        </div>
 
-      <div class="form-actions">
-        <a class="button ghost" href="/">Abbrechen</a>
-        <button type="submit" class="button">Konfiguration speichern</button>
-      </div>
-    </form>
+        <div class="section" style="margin-top: 1.5rem;">
+          <h2 class="card-title" style="font-size: 1.4rem;">Kategorien &amp; Anzahl Aufgaben</h2>
+          <p class="text-muted" style="margin-bottom: 1.5rem;">
+            Lege fest, aus welchen Kategorien wie viele Aufgaben automatisch gezogen werden sollen. Die Reihenfolge
+            bestimmt zugleich die Priorität bei der Auswahl.
+          </p>
+          <div id="requirements-list" class="requirement-grid"></div>
+          <button type="button" class="btn btn-secondary waves-effect" id="add-requirement">
+            <span class="material-icons left" aria-hidden="true">add_circle</span>
+            Kategorie hinzufügen
+          </button>
+        </div>
+
+        <div class="form-actions">
+          <a class="btn-flat waves-effect" href="/">Abbrechen</a>
+          <button type="submit" class="btn waves-effect waves-light">Konfiguration speichern</button>
+        </div>
+      </form>
+    </div>
   </div>
 {% endblock %}
 
@@ -39,25 +67,18 @@
   <script>
     const CATEGORY_OPTIONS = {{ category_options_json|safe }};
 
-    (function() {
+    document.addEventListener('DOMContentLoaded', () => {
+      let requirementIndex = 0;
       const listEl = document.getElementById('requirements-list');
       const addBtn = document.getElementById('add-requirement');
       const requirementsInput = document.getElementById('requirements-json');
-      const difficultyInput = document.getElementById('target-difficulty');
-      const difficultyDisplay = document.getElementById('target-difficulty-display');
-
-      const updateDifficultyDisplay = () => {
-        difficultyDisplay.textContent = `Stufe ${Number(difficultyInput.value).toFixed(1)}`;
-      };
-      difficultyInput.addEventListener('input', updateDifficultyDisplay);
-      updateDifficultyDisplay();
 
       function buildCategorySelect(selectedId) {
         const select = document.createElement('select');
         select.required = true;
         select.dataset.role = 'category';
         select.innerHTML = '<option value="" disabled selected>Kategorie wählen</option>';
-        CATEGORY_OPTIONS.forEach(option => {
+        CATEGORY_OPTIONS.forEach((option) => {
           const opt = document.createElement('option');
           opt.value = option.id;
           opt.textContent = option.name;
@@ -73,9 +94,9 @@
         const select = document.createElement('select');
         select.dataset.role = 'subcategory';
         select.innerHTML = '<option value="">Alle Unterkategorien</option>';
-        const category = CATEGORY_OPTIONS.find(option => String(option.id) === String(categoryId));
+        const category = CATEGORY_OPTIONS.find((option) => String(option.id) === String(categoryId));
         if (category && category.subcategories) {
-          category.subcategories.forEach(sub => {
+          category.subcategories.forEach((sub) => {
             const opt = document.createElement('option');
             opt.value = sub.id;
             opt.textContent = sub.name;
@@ -88,57 +109,66 @@
         return select;
       }
 
+      function createInputField(id, labelText, element) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'input-field';
+        element.id = id;
+        wrapper.appendChild(element);
+        const label = document.createElement('label');
+        label.setAttribute('for', id);
+        label.textContent = labelText;
+        label.classList.add('active');
+        wrapper.appendChild(label);
+        return wrapper;
+      }
+
       function createRequirementRow(initial) {
+        requirementIndex += 1;
         const row = document.createElement('div');
-        row.className = 'card requirement-row';
-        row.style.padding = '1rem';
-        row.style.display = 'grid';
-        row.style.gridTemplateColumns = 'repeat(auto-fit, minmax(180px, 1fr))';
-        row.style.gap = '0.75rem';
+        row.className = 'requirement-row';
 
-        const categoryField = document.createElement('div');
-        categoryField.className = 'form-field';
-        const categoryLabel = document.createElement('label');
-        categoryLabel.textContent = 'Kategorie';
         const categorySelect = buildCategorySelect(initial?.category_id);
-        categoryField.append(categoryLabel, categorySelect);
+        const categoryField = createInputField(`req-category-${requirementIndex}`, 'Kategorie', categorySelect);
 
-        const subcategoryField = document.createElement('div');
-        subcategoryField.className = 'form-field';
-        const subcategoryLabel = document.createElement('label');
-        subcategoryLabel.textContent = 'Unterkategorie';
-        const subcategorySelect = buildSubcategorySelect(initial?.category_id, initial?.subcategory_id);
-        subcategoryField.append(subcategoryLabel, subcategorySelect);
+        let subcategorySelect = buildSubcategorySelect(initial?.category_id, initial?.subcategory_id);
+        let subcategoryField = createInputField(
+          `req-subcategory-${requirementIndex}`,
+          'Unterkategorie',
+          subcategorySelect
+        );
 
-        const countField = document.createElement('div');
-        countField.className = 'form-field';
-        const countLabel = document.createElement('label');
-        countLabel.textContent = 'Aufgaben';
         const countInput = document.createElement('input');
         countInput.type = 'number';
         countInput.min = '1';
         countInput.value = initial?.question_count || 1;
         countInput.required = true;
         countInput.dataset.role = 'count';
-        countField.append(countLabel, countInput);
+        const countField = createInputField(`req-count-${requirementIndex}`, 'Aufgaben', countInput);
 
         const removeField = document.createElement('div');
-        removeField.className = 'form-field';
-        removeField.style.alignSelf = 'end';
+        removeField.className = 'requirement-actions';
         const removeBtn = document.createElement('button');
         removeBtn.type = 'button';
-        removeBtn.className = 'button ghost small';
+        removeBtn.className = 'btn-flat waves-effect red-text text-darken-1';
         removeBtn.textContent = 'Entfernen';
         removeBtn.addEventListener('click', () => {
           row.remove();
         });
-        removeField.append(removeBtn);
+        removeField.appendChild(removeBtn);
 
         categorySelect.addEventListener('change', () => {
           const current = subcategorySelect.value;
-          const nextSelect = buildSubcategorySelect(categorySelect.value, current);
-          nextSelect.dataset.role = 'subcategory';
-          subcategorySelect.replaceWith(nextSelect);
+          const replacement = buildSubcategorySelect(categorySelect.value, current);
+          replacement.dataset.role = 'subcategory';
+          const newField = createInputField(
+            `req-subcategory-${requirementIndex}`,
+            'Unterkategorie',
+            replacement
+          );
+          row.replaceChild(newField, subcategoryField);
+          subcategorySelect = replacement;
+          subcategoryField = newField;
+          window.AppUI?.refresh?.(newField);
         });
 
         row.append(categoryField, subcategoryField, countField, removeField);
@@ -148,19 +178,20 @@
       function addRequirement(initial) {
         const row = createRequirementRow(initial);
         listEl.appendChild(row);
+        window.AppUI?.refresh?.(row);
       }
 
       addBtn.addEventListener('click', () => addRequirement());
       addRequirement();
 
-      document.getElementById('configuration-form').addEventListener('submit', event => {
+      document.getElementById('configuration-form').addEventListener('submit', (event) => {
         const rows = Array.from(listEl.querySelectorAll('.requirement-row'));
         if (!rows.length) {
           event.preventDefault();
-          alert('Bitte füge mindestens eine Kategorie hinzu.');
+          M.toast({ html: 'Bitte füge mindestens eine Kategorie hinzu.', displayLength: 3000 });
           return;
         }
-        const requirements = rows.map(row => {
+        const requirements = rows.map((row) => {
           const categorySelect = row.querySelector('[data-role="category"]');
           const subcategorySelect = row.querySelector('[data-role="subcategory"]');
           const countInput = row.querySelector('[data-role="count"]');
@@ -170,13 +201,13 @@
             question_count: countInput.value || 1,
           };
         });
-        if (requirements.some(req => !req.category_id)) {
+        if (requirements.some((req) => !req.category_id)) {
           event.preventDefault();
-          alert('Bitte wähle für jede Zeile eine Kategorie aus.');
+          M.toast({ html: 'Bitte wähle für jede Zeile eine Kategorie aus.', displayLength: 3000 });
           return;
         }
         requirementsInput.value = JSON.stringify(requirements);
       });
-    })();
+    });
   </script>
 {% endblock %}

--- a/app/templates/exam_student.html
+++ b/app/templates/exam_student.html
@@ -4,19 +4,42 @@
 
 {% block head_extra %}
   <style>
-    header.topbar nav,
-    header.topbar .brand { display: none; }
-    body { background: #fff; }
-    main.container { max-width: 900px; }
+    nav.app-nav,
+    .sidenav,
+    .sidenav-trigger {
+      display: none !important;
+    }
+    body {
+      background: #f5f7fb;
+    }
+    .app-main {
+      padding-top: 2rem;
+    }
   </style>
 {% endblock %}
 
 {% block content %}
-  <section class="card" id="student-app" data-exam-id="{{ exam_id if exam_id else '' }}" data-live="{{ 'true' if live_mode else 'false' }}">
-    <h2 id="group-label">Prüfung</h2>
-    <div class="task-metadata">Diese Ansicht blendet Hinweise und Lösungen automatisch aus.</div>
-    <div id="tasks" class="exam-layout" style="margin-top:1.5rem;">
-      <p>Lade Aufgaben...</p>
+  <section
+    class="card"
+    id="student-app"
+    data-exam-id="{{ exam_id if exam_id else '' }}"
+    data-live="{{ 'true' if live_mode else 'false' }}"
+  >
+    <div class="card-content">
+      <h2 id="group-label" class="card-title" style="margin-bottom: 0.5rem;">Prüfung</h2>
+      <div class="task-metadata">Diese Ansicht blendet Hinweise und Lösungen automatisch aus.</div>
+      <div id="tasks" class="exam-task-grid" style="margin-top: 1.5rem;">
+        <div class="exam-task-card" style="text-align: center;">
+          <div class="preloader-wrapper small active">
+            <div class="spinner-layer spinner-blue-only">
+              <div class="circle-clipper left"><div class="circle"></div></div>
+              <div class="gap-patch"><div class="circle"></div></div>
+              <div class="circle-clipper right"><div class="circle"></div></div>
+            </div>
+          </div>
+          <p class="text-muted" style="margin-top: 1rem;">Lade Aufgaben…</p>
+        </div>
+      </div>
     </div>
   </section>
 {% endblock %}
@@ -26,45 +49,18 @@
     const appElement = document.getElementById('student-app');
     const tasksContainer = document.getElementById('tasks');
     const groupLabel = document.getElementById('group-label');
-    const examId = appElement.dataset.examId;
+    const initialExamId = appElement.dataset.examId;
     const isLive = appElement.dataset.live === 'true';
 
-    async function fetchExam() {
-      try {
-        const endpoint = isLive && !appElement.dataset.examId
-          ? '/api/exams/active'
-          : `/api/exams/${appElement.dataset.examId || examId}`;
-        const response = await fetch(endpoint);
-        if (!response.ok) {
-          if (response.status === 404 && isLive) {
-            groupLabel.textContent = 'Prüfung';
-            tasksContainer.innerHTML = '<p class="task-metadata">Aktuell ist keine Prüfung aktiv.</p>';
-            appElement.dataset.examId = '';
-            return;
-          }
-          throw new Error('Fehler beim Laden der Aufgaben');
-        }
-        const payload = await response.json();
-        renderExam(payload);
-        if (isLive) {
-          appElement.dataset.examId = payload.exam_id;
-        }
-      } catch (error) {
-        tasksContainer.innerHTML = `<p class="alert error">${error.message}</p>`;
-      }
-    }
-
-    function renderExam(exam) {
-      groupLabel.textContent = `Prüfung für ${exam.group.label}`;
-      if (!exam.tasks.length) {
-        tasksContainer.innerHTML = '<p>Keine Aufgaben verfügbar.</p>';
-        return;
-      }
-      tasksContainer.innerHTML = exam.tasks
+    function renderTasks(tasks) {
+      tasksContainer.innerHTML = tasks
         .map((task, index) => `
-          <article class="exam-task">
+          <article class="exam-task-card">
             <h2>${index + 1}. ${task.title}</h2>
-            <div class="task-metadata">${task.category}${task.subcategory ? ' · ' + task.subcategory : ''}</div>
+            <div class="task-metadata">
+              <span class="material-icons" aria-hidden="true">category</span>
+              ${task.category}${task.subcategory ? ' · ' + task.subcategory : ''}
+            </div>
             <div class="markdown">${task.statement_html}</div>
             ${task.image_urls && task.image_urls.length ? `
               <div class="task-images">
@@ -81,7 +77,47 @@
       }
     }
 
+    function renderEmptyState(message) {
+      tasksContainer.innerHTML = `
+        <article class="exam-task-card" style="text-align:center;">
+          <p class="text-muted">${message}</p>
+        </article>
+      `;
+    }
+
+    async function fetchExam() {
+      try {
+        const endpoint = isLive && !appElement.dataset.examId
+          ? '/api/exams/active'
+          : `/api/exams/${appElement.dataset.examId || initialExamId}`;
+        const response = await fetch(endpoint);
+        if (!response.ok) {
+          if (response.status === 404 && isLive) {
+            groupLabel.textContent = 'Prüfung';
+            renderEmptyState('Aktuell ist keine Prüfung aktiv.');
+            appElement.dataset.examId = '';
+            return;
+          }
+          throw new Error('Die Aufgaben konnten nicht geladen werden.');
+        }
+        const payload = await response.json();
+        groupLabel.textContent = `Prüfung für ${payload.group.label}`;
+        if (!payload.tasks.length) {
+          renderEmptyState('Keine Aufgaben verfügbar.');
+          return;
+        }
+        renderTasks(payload.tasks);
+        if (isLive) {
+          appElement.dataset.examId = payload.exam_id;
+        }
+      } catch (error) {
+        renderEmptyState(error.message || 'Die Aufgaben konnten nicht geladen werden.');
+      }
+    }
+
     fetchExam();
-    setInterval(fetchExam, 7000);
+    if (isLive) {
+      setInterval(fetchExam, 7000);
+    }
   </script>
 {% endblock %}

--- a/app/templates/exam_teacher.html
+++ b/app/templates/exam_teacher.html
@@ -4,50 +4,76 @@
 
 {% block content %}
   <section class="card">
-    <header style="display:flex; justify-content:space-between; align-items:center; gap:1rem; flex-wrap:wrap;">
-      <div>
-        <h2>Prüfung für {{ exam.group.label }}</h2>
-        <div class="task-metadata">
-          Studierende:
-          {% for student in exam.group.students %}
-            {{ student.full_name }}{% if not loop.last %}, {% endif %}
-          {% endfor %}
+    <div class="card-content">
+      <div class="exam-header">
+        <div class="exam-header__meta">
+          <h2 class="card-title" style="margin: 0;">Prüfung für {{ exam.group.label }}</h2>
+          <div class="task-metadata">
+            <span class="material-icons" aria-hidden="true">group</span>
+            Studierende:
+            {% for student in exam.group.students %}
+              {{ student.full_name }}{% if not loop.last %}, {% endif %}
+            {% endfor %}
+          </div>
+          <div class="task-metadata">
+            <span class="material-icons" aria-hidden="true">schedule</span>
+            Gestartet am {{ exam.started_at.strftime('%d.%m.%Y %H:%M') }} Uhr
+          </div>
         </div>
-        <div class="task-metadata">Gestartet am {{ exam.started_at.strftime('%d.%m.%Y %H:%M') }} Uhr</div>
+        <div class="exam-toolbar">
+          <a class="btn btn-secondary waves-effect" target="_blank" href="{{ request.url_for('show_exam_live') }}">
+            <span class="material-icons left" aria-hidden="true">open_in_new</span>
+            Studierendenansicht öffnen
+          </a>
+          <span class="task-metadata">
+            <span class="material-icons" aria-hidden="true">link</span>
+            Link teilen:
+            <code class="share-link">{{ request.url_for('show_exam_live') }}</code>
+          </span>
+          <form
+            method="post"
+            action="/exams/{{ exam.exam_id }}/regenerate"
+            onsubmit="return confirm('Aufgaben neu auslosen?');"
+          >
+            <button type="submit" class="btn btn-danger waves-effect">
+              <span class="material-icons left" aria-hidden="true">refresh</span>
+              Neue Aufgaben auslosen
+            </button>
+          </form>
+        </div>
       </div>
-      <div style="display:flex; flex-direction:column; gap:0.5rem; align-items:flex-end;">
-        <a class="button secondary" target="_blank" href="{{ request.url_for('show_exam_live') }}">Studierendenansicht öffnen</a>
-        <span class="task-metadata">Link teilen: <code class="share-link">{{ request.url_for('show_exam_live') }}</code></span>
-        <form method="post" action="/exams/{{ exam.exam_id }}/regenerate" onsubmit="return confirm('Aufgaben neu auslosen?');">
-          <button type="submit">Neue Aufgaben auslosen</button>
-        </form>
-      </div>
-    </header>
-    <div class="exam-layout" style="margin-top:1.5rem;">
-      {% for task in exam.tasks %}
-        <article class="exam-task">
-          <h2>{{ loop.index }}. {{ task.title }}</h2>
-          <div class="task-metadata">{{ task.category }}{% if task.subcategory %} · {{ task.subcategory }}{% endif %}</div>
-          <div class="markdown">{{ task.statement_html | safe }}</div>
-          {% if task.image_urls %}
-            <div class="task-images">
-              {% for image_url in task.image_urls %}
-                <figure>
-                  <img src="{{ image_url }}" alt="Aufgabenbild {{ loop.index }}" />
-                </figure>
-              {% endfor %}
+
+      <div class="exam-task-grid" style="margin-top: 2rem;">
+        {% for task in exam.tasks %}
+          <article class="exam-task-card">
+            <h2>{{ loop.index }}. {{ task.title }}</h2>
+            <div class="task-metadata">
+              <span class="material-icons" aria-hidden="true">category</span>
+              {{ task.category }}{% if task.subcategory %} · {{ task.subcategory }}{% endif %}
+              <span class="material-icons" aria-hidden="true">insights</span>
+              Schwierigkeitsstufe {{ task.difficulty or '–' }}
             </div>
-          {% endif %}
-          {% if task.hints_html %}
-            <div class="section-title">Hinweise</div>
-            <div class="markdown">{{ task.hints_html | safe }}</div>
-          {% endif %}
-          {% if task.solution_html %}
-            <div class="section-title">Lösung</div>
-            <div class="markdown">{{ task.solution_html | safe }}</div>
-          {% endif %}
-        </article>
-      {% endfor %}
+            <div class="markdown">{{ task.statement_html | safe }}</div>
+            {% if task.image_urls %}
+              <div class="task-images">
+                {% for image_url in task.image_urls %}
+                  <figure>
+                    <img src="{{ image_url }}" alt="Aufgabenbild {{ loop.index }}" />
+                  </figure>
+                {% endfor %}
+              </div>
+            {% endif %}
+            {% if task.hints_html %}
+              <div class="section-title">Hinweise</div>
+              <div class="markdown">{{ task.hints_html | safe }}</div>
+            {% endif %}
+            {% if task.solution_html %}
+              <div class="section-title">Lösung</div>
+              <div class="markdown">{{ task.solution_html | safe }}</div>
+            {% endif %}
+          </article>
+        {% endfor %}
+      </div>
     </div>
   </section>
 {% endblock %}

--- a/app/templates/tasks_form.html
+++ b/app/templates/tasks_form.html
@@ -18,157 +18,168 @@
 {% block content %}
   <h1 class="page-title">{{ page_title }}</h1>
 
-  <div class="form-card">
-    <form
-      id="task-form"
-      method="post"
-      enctype="multipart/form-data"
-      action="{% if task %}/tasks/{{ task.id }}{% else %}/tasks{% endif %}"
-    >
-      <input type="hidden" name="crop_metadata" id="crop-metadata" />
-      <div class="form-grid">
-        <div class="form-field">
-          <label for="title">Titel</label>
-          <input id="title" type="text" name="title" value="{{ task.title if task else '' }}" required />
-        </div>
-        <div class="form-field">
-          <label for="category_id">Kategorie</label>
-          <select id="category_id" name="category_id" required>
-            <option value="" disabled {% if not selected_category_id %}selected{% endif %}>Kategorie wählen</option>
-            {% for category in categories %}
-              <option value="{{ category.id }}" {% if selected_category_id == category.id %}selected{% endif %}>{{ category.name }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="form-field">
-          <label for="subcategory_id">Unterkategorie</label>
-          <select
-            id="subcategory_id"
-            name="subcategory_id"
-            data-selected="{{ selected_subcategory_id if selected_subcategory_id else '' }}"
-          >
-            <option value="" {% if not selected_subcategory_id %}selected{% endif %}>Keine Unterkategorie</option>
-            {% if selected_category_id %}
-              {% for category in categories %}
-                {% if category.id == selected_category_id %}
-                  {% for subcategory in category.children %}
-                    <option value="{{ subcategory.id }}" {% if selected_subcategory_id == subcategory.id %}selected{% endif %}>{{ subcategory.name }}</option>
-                  {% endfor %}
-                {% endif %}
-              {% endfor %}
-            {% endif %}
-          </select>
-        </div>
-        <div class="form-field">
-          <label for="difficulty">Schwierigkeitsstufe</label>
-          <select id="difficulty" name="difficulty" required>
-            <option value="1" {% if task and task.difficulty == 1 %}selected{% endif %}>1 · Grundlagen</option>
-            <option value="2" {% if not task or task.difficulty == 2 %}selected{% endif %}>2 · Fortgeschritten</option>
-            <option value="3" {% if task and task.difficulty == 3 %}selected{% endif %}>3 · Anspruchsvoll</option>
-          </select>
-        </div>
-      </div>
+  <div class="card form-card">
+    <div class="card-content">
+      <form
+        id="task-form"
+        method="post"
+        enctype="multipart/form-data"
+        action="{% if task %}/tasks/{{ task.id }}{% else %}/tasks{% endif %}"
+      >
+        <input type="hidden" name="crop_metadata" id="crop-metadata" />
 
-      <div class="form-field markdown-editor">
-        <label for="statement_markdown">Aufgabe (Markdown)</label>
-        <div class="markdown-editor-grid">
-          <textarea
-            id="statement_markdown"
-            name="statement_markdown"
-            data-preview-target="statement-preview"
-            required
-          >{{ task.statement_markdown if task else '' }}</textarea>
+        <div class="row">
+          <div class="input-field col s12 m6">
+            <input id="title" type="text" name="title" value="{{ task.title if task else '' }}" required />
+            <label for="title" {% if task %}class="active"{% endif %}>Titel</label>
+          </div>
+          <div class="input-field col s12 m6">
+            <select id="category_id" name="category_id" required>
+              <option value="" disabled {% if not selected_category_id %}selected{% endif %}>Kategorie wählen</option>
+              {% for category in categories %}
+                <option value="{{ category.id }}" {% if selected_category_id == category.id %}selected{% endif %}>{{ category.name }}</option>
+              {% endfor %}
+            </select>
+            <label for="category_id">Kategorie</label>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="input-field col s12 m6">
+            <select
+              id="subcategory_id"
+              name="subcategory_id"
+              data-selected="{{ selected_subcategory_id if selected_subcategory_id else '' }}"
+            >
+              <option value="" {% if not selected_subcategory_id %}selected{% endif %}>Keine Unterkategorie</option>
+              {% if selected_category_id %}
+                {% for category in categories %}
+                  {% if category.id == selected_category_id %}
+                    {% for subcategory in category.children %}
+                      <option value="{{ subcategory.id }}" {% if selected_subcategory_id == subcategory.id %}selected{% endif %}>{{ subcategory.name }}</option>
+                    {% endfor %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            </select>
+            <label for="subcategory_id">Unterkategorie</label>
+          </div>
+          <div class="input-field col s12 m6">
+            <select id="difficulty" name="difficulty" required>
+              <option value="1" {% if task and task.difficulty == 1 %}selected{% endif %}>1 · Grundlagen</option>
+              <option value="2" {% if not task or task.difficulty == 2 %}selected{% endif %}>2 · Fortgeschritten</option>
+              <option value="3" {% if task and task.difficulty == 3 %}selected{% endif %}>3 · Anspruchsvoll</option>
+            </select>
+            <label for="difficulty">Schwierigkeitsstufe</label>
+          </div>
+        </div>
+
+        <div class="section">
+          <h2 class="card-title" style="font-size: 1.4rem; margin-bottom: 1rem;">Inhalte</h2>
+          <div class="input-field" style="margin-bottom: 1.5rem;">
+            <textarea
+              id="statement_markdown"
+              name="statement_markdown"
+              class="materialize-textarea"
+              data-preview-target="statement-preview"
+              required
+            >{{ task.statement_markdown if task else '' }}</textarea>
+            <label for="statement_markdown" class="active">Aufgabe (Markdown)</label>
+          </div>
           <div class="markdown-preview" id="statement-preview"></div>
         </div>
-      </div>
 
-      <div class="form-field markdown-editor">
-        <label for="hints_markdown">Hinweise (optional)</label>
-        <div class="markdown-editor-grid">
-          <textarea
-            id="hints_markdown"
-            name="hints_markdown"
-            data-preview-target="hints-preview"
-          >{{ task.hints_markdown if task and task.hints_markdown else '' }}</textarea>
+        <div class="section" style="margin-top: 2rem;">
+          <div class="input-field" style="margin-bottom: 1.5rem;">
+            <textarea
+              id="hints_markdown"
+              name="hints_markdown"
+              class="materialize-textarea"
+              data-preview-target="hints-preview"
+            >{{ task.hints_markdown if task and task.hints_markdown else '' }}</textarea>
+            <label for="hints_markdown" class="active">Hinweise (optional)</label>
+          </div>
           <div class="markdown-preview" id="hints-preview"></div>
         </div>
-      </div>
 
-      <div class="form-field markdown-editor">
-        <label for="solution_markdown">Lösung (optional)</label>
-        <div class="markdown-editor-grid">
-          <textarea
-            id="solution_markdown"
-            name="solution_markdown"
-            data-preview-target="solution-preview"
-          >{{ task.solution_markdown if task and task.solution_markdown else '' }}</textarea>
+        <div class="section" style="margin-top: 2rem;">
+          <div class="input-field" style="margin-bottom: 1.5rem;">
+            <textarea
+              id="solution_markdown"
+              name="solution_markdown"
+              class="materialize-textarea"
+              data-preview-target="solution-preview"
+            >{{ task.solution_markdown if task and task.solution_markdown else '' }}</textarea>
+            <label for="solution_markdown" class="active">Lösung (optional)</label>
+          </div>
           <div class="markdown-preview" id="solution-preview"></div>
         </div>
-      </div>
 
-      <div class="form-field">
-        <label for="dependency_ids">Abhängigkeiten (IDs, Komma getrennt)</label>
-        <input
-          id="dependency_ids"
-          type="text"
-          name="dependency_ids"
-          value="{% if task and task.dependencies %}{% for dep in task.dependencies %}{{ dep.id }}{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}"
-          placeholder="z. B. 12, 18"
-        />
-      </div>
-
-      <div class="form-field">
-        <label for="images">Anhänge (Bilder)</label>
-        <input id="images" type="file" name="images" accept="image/*" multiple />
-        <small class="text-muted">Bilder werden automatisch auf 4:3 zugeschnitten und auf 1200×900 px skaliert.</small>
-        <div class="task-media-preview" id="image-preview"></div>
-      </div>
-
-      {% if task and task.images %}
-        <div class="form-field">
-          <label>Vorhandene Bilder</label>
-          <div class="image-gallery">
-            {% for image in task.images %}
-              <figure>
-                <img src="{{ url_for('static', path=image.thumbnail_path or image.file_path) }}" alt="{{ image.original_filename }}" />
-                <figcaption>{{ image.original_filename }}</figcaption>
-                <label class="remove-toggle">
-                  <input type="checkbox" name="remove_image_ids" value="{{ image.id }}" /> Entfernen
-                </label>
-              </figure>
-            {% endfor %}
+        <div class="row">
+          <div class="input-field col s12 m6">
+            <input
+              id="dependency_ids"
+              type="text"
+              name="dependency_ids"
+              value="{% if task and task.dependencies %}{% for dep in task.dependencies %}{{ dep.id }}{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}"
+            />
+            <label for="dependency_ids" class="active">Abhängigkeiten (IDs, Komma getrennt)</label>
+            <span class="helper-text">z. B. 12, 18</span>
+          </div>
+          <div class="input-field col s12 m6">
+            <input id="images" type="file" name="images" accept="image/*" multiple />
+            <label for="images" class="active">Anhänge (Bilder)</label>
+            <span class="helper-text">Bilder werden automatisch zugeschnitten (4:3) und skaliert.</span>
+            <div class="task-media-preview" id="image-preview"></div>
           </div>
         </div>
-      {% endif %}
 
-      {% if all_tasks %}
-        <div class="form-field">
-          <label>Verfügbare Aufgaben</label>
-          <div class="markdown-preview" style="max-height:180px; overflow:auto;">
-            {% for other in all_tasks %}
-              #{{ other.id }} · {{ other.title }} ({{ other.category }})<br />
-            {% endfor %}
+        {% if task and task.images %}
+          <div class="section" style="margin-top: 2rem;">
+            <h3 style="margin-top: 0;">Vorhandene Bilder</h3>
+            <div class="image-gallery">
+              {% for image in task.images %}
+                <figure>
+                  <img src="{{ url_for('static', path=image.thumbnail_path or image.file_path) }}" alt="{{ image.original_filename }}" />
+                  <figcaption>{{ image.original_filename }}</figcaption>
+                  <label class="remove-toggle">
+                    <input type="checkbox" name="remove_image_ids" value="{{ image.id }}" /> Entfernen
+                  </label>
+                </figure>
+              {% endfor %}
+            </div>
           </div>
-        </div>
-      {% endif %}
+        {% endif %}
 
-      <div class="form-actions">
-        <a class="button ghost" href="/tasks">Abbrechen</a>
-        <button type="submit" class="button">Speichern</button>
-      </div>
-    </form>
+        {% if all_tasks %}
+          <div class="section" style="margin-top: 2rem;">
+            <h3 style="margin-top: 0;">Verfügbare Aufgaben</h3>
+            <div class="markdown-preview" style="max-height: 200px; overflow: auto;">
+              {% for other in all_tasks %}
+                #{{ other.id }} · {{ other.title }} ({{ other.category }})<br />
+              {% endfor %}
+            </div>
+          </div>
+        {% endif %}
+
+        <div class="form-actions">
+          <a class="btn-flat waves-effect" href="/tasks">Abbrechen</a>
+          <button type="submit" class="btn waves-effect waves-light">Speichern</button>
+        </div>
+      </form>
+    </div>
   </div>
 
-  <div class="modal" id="crop-modal" role="dialog" aria-modal="true" aria-labelledby="crop-modal-title">
-    <div class="modal__content">
-      <h3 id="crop-modal-title">Bild zuschneiden</h3>
+  <div id="crop-modal" class="modal">
+    <div class="modal-content">
+      <h4>Bild zuschneiden</h4>
       <div class="crop-container">
         <img id="crop-image" alt="Vorschau zum Zuschnitt" />
       </div>
-      <div class="modal__actions">
-        <button type="button" class="button ghost" id="crop-cancel">Abbrechen</button>
-        <button type="button" class="button" id="crop-apply">Zuschnitt übernehmen</button>
-      </div>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="modal-close btn-flat" id="crop-cancel">Abbrechen</button>
+      <button type="button" class="btn waves-effect waves-light" id="crop-apply">Zuschnitt übernehmen</button>
     </div>
   </div>
 {% endblock %}
@@ -176,199 +187,181 @@
 {% block scripts %}
   <script src="https://cdn.jsdelivr.net/npm/cropperjs@1.6.1/dist/cropper.min.js"></script>
   <script>
-    const categoryOptions = {{ category_options_json | safe }};
-    const categorySelect = document.getElementById('category_id');
-    const subcategorySelect = document.getElementById('subcategory_id');
+    document.addEventListener('DOMContentLoaded', () => {
+      const categoryOptions = {{ category_options_json | safe }};
+      const categorySelect = document.getElementById('category_id');
+      const subcategorySelect = document.getElementById('subcategory_id');
 
-    function populateSubcategories(selectedCategoryId) {
-      const currentSelection = subcategorySelect.dataset.selected || '';
-      subcategorySelect.innerHTML = '';
-      const defaultOption = document.createElement('option');
-      defaultOption.value = '';
-      defaultOption.textContent = 'Keine Unterkategorie';
-      if (!currentSelection) {
-        defaultOption.selected = true;
-      }
-      subcategorySelect.appendChild(defaultOption);
+      if (categorySelect && subcategorySelect) {
+        function repopulateSubcategories(selectedCategoryId) {
+          const currentSelection = subcategorySelect.dataset.selected || '';
+          subcategorySelect.innerHTML = '';
+          const defaultOption = document.createElement('option');
+          defaultOption.value = '';
+          defaultOption.textContent = 'Keine Unterkategorie';
+          if (!currentSelection) {
+            defaultOption.selected = true;
+          }
+          subcategorySelect.appendChild(defaultOption);
 
-      const category = categoryOptions.find((entry) => entry.id === Number(selectedCategoryId));
-      if (!category) {
-        subcategorySelect.dataset.selected = '';
-        return;
-      }
+          const category = categoryOptions.find((entry) => entry.id === Number(selectedCategoryId));
+          if (!category) {
+            subcategorySelect.dataset.selected = '';
+            delete subcategorySelect.dataset.mInitialized;
+            window.AppUI?.initSelects?.(subcategorySelect.parentElement || document);
+            return;
+          }
 
-      category.subcategories.forEach((subcategory) => {
-        const option = document.createElement('option');
-        option.value = String(subcategory.id);
-        option.textContent = subcategory.name;
-        if (Number(currentSelection) === subcategory.id) {
-          option.selected = true;
-        }
-        subcategorySelect.appendChild(option);
-      });
-    }
-
-    if (categorySelect) {
-      categorySelect.addEventListener('change', (event) => {
-        subcategorySelect.dataset.selected = '';
-        populateSubcategories(event.target.value);
-      });
-
-      if (categorySelect.value) {
-        populateSubcategories(categorySelect.value);
-      }
-    }
-
-    function setupMarkdownPreview(textarea) {
-      const previewId = textarea.dataset.previewTarget;
-      const previewElement = document.getElementById(previewId);
-      if (!previewElement) {
-        return;
-      }
-
-      let timeoutId = null;
-      let abortController = null;
-
-      async function renderPreview() {
-        const content = textarea.value;
-        if (abortController) {
-          abortController.abort();
-        }
-        abortController = new AbortController();
-        try {
-          const response = await fetch('/api/markdown/preview', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            signal: abortController.signal,
-            body: JSON.stringify({ markdown: content }),
+          category.subcategories.forEach((subcategory) => {
+            const option = document.createElement('option');
+            option.value = String(subcategory.id);
+            option.textContent = subcategory.name;
+            if (String(subcategory.id) === currentSelection) {
+              option.selected = true;
+            }
+            subcategorySelect.appendChild(option);
           });
-          if (!response.ok) {
-            throw new Error('Fehler beim Rendern der Vorschau');
+
+          if (!category.subcategories.length) {
+            subcategorySelect.dataset.selected = '';
           }
-          const data = await response.json();
-          previewElement.innerHTML = data.html || '';
-        } catch (error) {
-          if (error.name !== 'AbortError') {
-            console.error(error);
-          }
+
+          delete subcategorySelect.dataset.mInitialized;
+          window.AppUI?.initSelects?.(subcategorySelect.parentElement || document);
+        }
+
+        categorySelect.addEventListener('change', (event) => {
+          subcategorySelect.dataset.selected = '';
+          repopulateSubcategories(event.target.value);
+        });
+
+        repopulateSubcategories(categorySelect.value);
+      }
+
+      const imageInput = document.getElementById('images');
+      const previewContainer = document.getElementById('image-preview');
+      const cropModalElement = document.getElementById('crop-modal');
+      const cropModal = window.M && window.M.Modal ? M.Modal.init(cropModalElement, { dismissible: false }) : null;
+      const cropImage = document.getElementById('crop-image');
+      const cropApply = document.getElementById('crop-apply');
+      const cropCancel = document.getElementById('crop-cancel');
+      const cropMetadataField = document.getElementById('crop-metadata');
+
+      const cropQueue = [];
+      const cropMetadata = {};
+      let cropper = null;
+      let modalIsOpen = false;
+
+      function openCropModal() {
+        if (!cropModal) {
+          return;
+        }
+        cropModal.open();
+        modalIsOpen = true;
+      }
+
+      function closeCropModal() {
+        if (cropModal) {
+          cropModal.close();
+        }
+        modalIsOpen = false;
+        if (cropper) {
+          cropper.destroy();
+          cropper = null;
         }
       }
 
-      textarea.addEventListener('input', () => {
-        clearTimeout(timeoutId);
-        timeoutId = window.setTimeout(renderPreview, 250);
-      });
-
-      renderPreview();
-    }
-
-    document.querySelectorAll('[data-preview-target]').forEach(setupMarkdownPreview);
-
-    // Bildzuschnitt
-    const imageInput = document.getElementById('images');
-    const previewContainer = document.getElementById('image-preview');
-    const cropModal = document.getElementById('crop-modal');
-    const cropImage = document.getElementById('crop-image');
-    const cropApply = document.getElementById('crop-apply');
-    const cropCancel = document.getElementById('crop-cancel');
-    const cropMetadataField = document.getElementById('crop-metadata');
-
-    const cropQueue = [];
-    const cropMetadata = {};
-    let cropper = null;
-
-    function openModal() {
-      cropModal.classList.add('is-open');
-    }
-
-    function closeModal() {
-      cropModal.classList.remove('is-open');
-      if (cropper) {
-        cropper.destroy();
-        cropper = null;
-      }
-    }
-
-    function processNextCrop() {
-      if (!cropQueue.length) {
-        closeModal();
-        return;
-      }
-      const current = cropQueue.shift();
-      cropImage.src = current.dataUrl;
-      openModal();
-      requestAnimationFrame(() => {
-        cropper = new Cropper(cropImage, {
-          aspectRatio: 4 / 3,
-          viewMode: 1,
-          autoCropArea: 1,
-        });
-        cropApply.onclick = () => {
-          const data = cropper.getData();
-          cropMetadata[current.file.name] = {
-            x: data.x,
-            y: data.y,
-            width: data.width,
-            height: data.height,
-          };
-          closeModal();
-          processNextCrop();
-        };
-        cropCancel.onclick = () => {
-          delete cropMetadata[current.file.name];
-          closeModal();
-          processNextCrop();
-        };
-      });
-    }
-
-    function queueCrop(file, dataUrl) {
-      cropQueue.push({ file, dataUrl });
-      if (!cropper && !cropModal.classList.contains('is-open')) {
-        processNextCrop();
-      }
-    }
-
-    function handleFilePreview(file, dataUrl, needsCrop) {
-      const img = document.createElement('img');
-      img.src = dataUrl;
-      img.alt = file.name;
-      previewContainer.appendChild(img);
-      if (!needsCrop) {
-        delete cropMetadata[file.name];
-      }
-    }
-
-    if (imageInput) {
-      imageInput.addEventListener('change', () => {
-        previewContainer.innerHTML = '';
-        cropQueue.length = 0;
-        closeModal();
-        Object.keys(cropMetadata).forEach((key) => delete cropMetadata[key]);
-        Array.from(imageInput.files || []).forEach((file) => {
-          const reader = new FileReader();
-          reader.onload = (event) => {
-            const dataUrl = event.target.result;
-            const img = new Image();
-            img.onload = () => {
-              const ratio = img.width / img.height;
-              const needsCrop = Math.abs(ratio - 4 / 3) > 0.02;
-              handleFilePreview(file, dataUrl, needsCrop);
-              if (needsCrop) {
-                queueCrop(file, dataUrl);
-              }
+      function processCropQueue() {
+        if (!cropQueue.length || !cropModal) {
+          closeCropModal();
+          return;
+        }
+        const current = cropQueue.shift();
+        cropImage.src = current.dataUrl;
+        openCropModal();
+        requestAnimationFrame(() => {
+          cropper = new Cropper(cropImage, {
+            aspectRatio: 4 / 3,
+            viewMode: 1,
+            autoCropArea: 1,
+          });
+          cropApply.onclick = () => {
+            const data = cropper.getData();
+            cropMetadata[current.file.name] = {
+              x: data.x,
+              y: data.y,
+              width: data.width,
+              height: data.height,
             };
-            img.src = dataUrl;
+            closeCropModal();
+            processCropQueue();
           };
-          reader.readAsDataURL(file);
+          cropCancel.onclick = () => {
+            delete cropMetadata[current.file.name];
+            closeCropModal();
+            processCropQueue();
+          };
         });
-      });
-    }
+      }
 
-    document.getElementById('task-form').addEventListener('submit', () => {
-      cropMetadataField.value = JSON.stringify(cropMetadata);
+      function queueCrop(file, dataUrl) {
+        if (!cropModal) {
+          return;
+        }
+        cropQueue.push({ file, dataUrl });
+        if (!cropper && !modalIsOpen) {
+          processCropQueue();
+        }
+      }
+
+      function renderPreviewThumbnail(file, dataUrl, requiresCrop) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'preview-thumb';
+        const img = document.createElement('img');
+        img.src = dataUrl;
+        img.alt = file.name;
+        wrapper.appendChild(img);
+        if (requiresCrop) {
+          const chip = document.createElement('span');
+          chip.className = 'badge';
+          chip.textContent = 'Zuschnitt empfohlen';
+          wrapper.appendChild(chip);
+        }
+        previewContainer.appendChild(wrapper);
+        if (!requiresCrop) {
+          delete cropMetadata[file.name];
+        }
+      }
+
+      if (imageInput) {
+        imageInput.addEventListener('change', () => {
+          previewContainer.innerHTML = '';
+          cropQueue.length = 0;
+          closeCropModal();
+          Object.keys(cropMetadata).forEach((key) => delete cropMetadata[key]);
+          Array.from(imageInput.files || []).forEach((file) => {
+            const reader = new FileReader();
+            reader.onload = (event) => {
+              const dataUrl = event.target.result;
+              const probe = new Image();
+              probe.onload = () => {
+                const ratio = probe.width / probe.height;
+                const requiresCrop = Math.abs(ratio - 4 / 3) > 0.02;
+                renderPreviewThumbnail(file, dataUrl, requiresCrop);
+                if (requiresCrop) {
+                  queueCrop(file, dataUrl);
+                }
+              };
+              probe.src = dataUrl;
+            };
+            reader.readAsDataURL(file);
+          });
+        });
+      }
+
+      document.getElementById('task-form').addEventListener('submit', () => {
+        cropMetadataField.value = JSON.stringify(cropMetadata);
+      });
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- adopt Materialize for the global layout and styling, updating the navigation bar and shared palette
- add a front-end helper script to initialize Material components and render live Markdown previews
- restyle categories, task authoring, and exam views with Material cards, segmented controls, and richer previews while exposing task difficulty in the exam payload

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d460e74420832c8a551d349d18fe98