### PR TITLE
Fix Materialize CDN integrity hashes

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -16,7 +16,7 @@
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"
-      integrity="sha512-1BM8w9Wm0K6UyjmOYGUWZAXgY0x0JBoYxKxO6jwxKF1u9IiMaTZGi4ZTSdKCbFf8gIuwZPzH0JwS4gS2y2zYKw=="
+      integrity="sha512-UJfAaOlIRtdR+0P6C3KUoTDAxVTuy3lnSXLyLKlHYJlcSU8Juge/mjeaxDNMlw9LgeIotgz5FP8eUQPhX1q10A=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
@@ -76,7 +76,7 @@
     </main>
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"
-      integrity="sha512-CZ6PvUCaY/0ZUqKoU0uUUtSRm4jOvrlesBxgVjbBc088DujzUyi4QxMauPDXmgZxziWSr0IkLk1q0sY1b02sxQ=="
+      integrity="sha512-NiWqa2rceHnN3Z5j6mSAvbwwg3tiwVNxiAQaaSMSXnRRDh5C2mk/+sKQRw8qjV1vN4nf8iK2a0b048PnHbyx+Q=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
       defer


### PR DESCRIPTION
## Summary
- update the Materialize CSS and JS CDN integrity attributes to the correct SHA-512 hashes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4658f71d4832c830e541b25efa3cc